### PR TITLE
cloud-connector: add support for DELETE'ing objects in S3 store

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -35,15 +35,18 @@ class ProviderResponse(object):
         wsgi_status = '%d %s' % (self.status, RESPONSE_REASONS[self.status][0])
         return wsgi_status, self.headers.items(), self.body
 
-    def __repr__(self):
-        return '<%s: %s, %r, %r, %r>' % (
-            self.__class__.__name__, self.success, self.status, self.headers,
-            (self.body or '')[:70])
-
     def reraise(self):
         if self.exc_info:
             raise self.exc_info[0], self.exc_info[1], self.exc_info[2]
-        raise ValueError('reraise had no prior exception for %r' % self)
+        header_str = '{' + ', '.join('%r: %r' % (k, self.headers[k])
+                                     for k in sorted(self.headers)) + '}'
+        body_str = ''.join(self.body) if self.body else ''
+        if len(body_str) > 70:
+            body_str = body_str[:70] + '...'
+        me_as_a_str = '<%s: %s, %r, %s, %r>' % (
+            self.__class__.__name__, self.success, self.status,
+            header_str, body_str)
+        raise ValueError('reraise had no prior exception for %s' % me_as_a_str)
 
 
 class BaseSync(object):

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -22,6 +22,7 @@ import eventlet
 import hashlib
 import json
 import re
+import sys
 import traceback
 import urllib
 
@@ -179,25 +180,25 @@ class SyncS3(BaseSync):
                 params['ServerSideEncryption'] = 'AES256'
             s3_client.put_object(**params)
 
-    def _delete_not_found(self, s3_key):
-        '''Deletes the object and ignores the 404 Not Found error.'''
-        with self.client_pool.get_client() as s3_client:
-            try:
-                s3_client.delete_object(Bucket=self.aws_bucket, Key=s3_key)
-            except botocore.exceptions.ClientError as e:
-                resp_meta = e.response.get('ResponseMetadata', {})
-                if resp_meta.get('HTTPStatusCode', 0) == 404:
-                    self.logger.warning('%s already removed from %s' % (
-                        s3_key, self.aws_bucket))
-                else:
-                    raise
-
     def delete_object(self, swift_key):
         s3_key = self.get_s3_name(swift_key)
         self.logger.debug('Deleting object %s' % s3_key)
-        self._delete_not_found(s3_key)
+        resp = self._call_boto('delete_object', Bucket=self.aws_bucket,
+                               Key=s3_key)
+        if not resp.success:
+            if resp.status == 404:
+                self.logger.warning('%s already removed from %s', s3_key,
+                                    self.aws_bucket)
+            else:
+                resp.reraise()
         # If there is a manifest uploaded for this object, remove it as well
-        self._delete_not_found(self.get_manifest_name(s3_key))
+        resp_manifest = self._call_boto('delete_object',
+                                        Bucket=self.aws_bucket,
+                                        Key=self.get_manifest_name(s3_key))
+        if not resp_manifest.success and resp_manifest.status != 404:
+            resp_manifest.reraise()
+
+        return resp
 
     def shunt_object(self, req, swift_key):
         """Fetch an object from the remote cluster to stream back to a client.
@@ -316,11 +317,14 @@ class SyncS3(BaseSync):
                 body = resp.get('Body', iter(['']))
                 if 'CopyObjectResult' in resp:
                     return ProviderResponse(True, 200, {}, body)
+                if ('ResponseMetadata' not in resp and
+                        op == 'delete_object'):
+                    return ProviderResponse(True, 204, {}, body)
 
                 return ProviderResponse(
                     True, resp['ResponseMetadata']['HTTPStatusCode'],
                     convert_to_swift_headers(
-                        resp['ResponseMetadata']['HTTPHeaders']),
+                        resp['ResponseMetadata'].get('HTTPHeaders', {})),
                     body)
             except botocore.exceptions.ClientError as e:
                 self.logger.debug(
@@ -329,11 +333,16 @@ class SyncS3(BaseSync):
                     self.settings['aws_bucket'].encode('utf8'),
                     self.settings['aws_identity'].encode('utf8'),
                     e.response)
-                return ProviderResponse(
-                    False, e.response['ResponseMetadata']['HTTPStatusCode'],
-                    convert_to_swift_headers(
-                        e.response['ResponseMetadata']['HTTPHeaders']),
-                    iter(e.response['Error']['Message']))
+                status = 502
+                headers = {}
+                message = 'Bad Gateway'
+                if 'ResponseMetadata' in e.response:
+                    status = e.response['ResponseMetadata']['HTTPStatusCode']
+                    headers = convert_to_swift_headers(
+                        e.response['ResponseMetadata'].get('HTTPHeaders', {}))
+                    message = e.response.get('Error', {}).get('Message', '')
+                return ProviderResponse(False, status, headers, iter(message),
+                                        exc_info=sys.exc_info())
             except Exception as e:
                 self.logger.exception(
                     'Error with S3 API %r to %s/%s (key_id: %s): %r',
@@ -341,7 +350,8 @@ class SyncS3(BaseSync):
                     self.settings['aws_bucket'].encode('utf8'),
                     self.settings['aws_identity'].encode('utf8'),
                     e.message)
-                return ProviderResponse(False, 502, {}, iter(['Bad Gateway']))
+                return ProviderResponse(False, 502, {}, iter(['Bad Gateway']),
+                                        exc_info=sys.exc_info())
 
         if op == 'get_object':
             entry = self.client_pool.get_client()

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -315,6 +315,12 @@ class SyncS3(BaseSync):
             try:
                 resp = getattr(s3_client, op)(**args)
                 body = resp.get('Body', iter(['']))
+
+                # S3 API responses are inconsistent, so there will be various
+                # special-cases here.  This one about CopyObjectResult is for
+                # PUTs that copy objects (to update metadata or whatever).
+                # The API response for delete_object is also different (but
+                # only sometimes?).
                 if 'CopyObjectResult' in resp:
                     return ProviderResponse(True, 200, {}, body)
                 if ('ResponseMetadata' not in resp and

--- a/s3_sync/verify.py
+++ b/s3_sync/verify.py
@@ -74,8 +74,8 @@ def validate_bucket(provider, swift_key, create_bucket):
         return 'Unexpected status code listing bucket: %d' % result.status
 
     result = provider.delete_object(swift_key)
-    if result is not None:
-        return result
+    if result is not None and not result.success:
+        return 'Unexpected status code deleting obj: %s' % result.status
 
     if create_bucket:
         # Clean up after ourselves

--- a/test/unit/test_base_sync.py
+++ b/test/unit/test_base_sync.py
@@ -15,7 +15,9 @@ limitations under the License.
 """
 
 import mock
-from s3_sync.base_sync import BaseSync
+from s3_sync import base_sync
+from swift.common import swob
+import sys
 import unittest
 
 
@@ -31,7 +33,7 @@ class TestBaseSync(unittest.TestCase):
     def test_http_pool_locking(self, factory_mock):
         factory_mock.return_value = mock.Mock()
 
-        base = BaseSync(self.settings, max_conns=1)
+        base = base_sync.BaseSync(self.settings, max_conns=1)
         with base.client_pool.get_client():
             self.assertEqual(0, base.client_pool.get_semaphore.balance)
             self.assertEqual(
@@ -42,7 +44,7 @@ class TestBaseSync(unittest.TestCase):
     def test_double_release(self, factory_mock):
         factory_mock.return_value = mock.Mock()
 
-        base = BaseSync(self.settings, max_conns=1)
+        base = base_sync.BaseSync(self.settings, max_conns=1)
         client = base.client_pool.get_client()
         self.assertEqual(0, base.client_pool.get_semaphore.balance)
         self.assertEqual(
@@ -54,3 +56,50 @@ class TestBaseSync(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             client.close()
         self.assertEqual(1, client.semaphore.balance)
+
+    def test_provider_response_reraise(self):
+        def blammo():
+            raise Exception('boom?')
+
+        try:
+            blammo()
+        except Exception:
+            r = base_sync.ProviderResponse(False, 404, {}, iter(['']),
+                                           exc_info=sys.exc_info())
+
+        with self.assertRaises(Exception) as cm:
+            r.reraise()
+
+        self.assertEqual('boom?', cm.exception.message)
+
+    def test_provider_response_reraise_no_exc_info(self):
+        headers = swob.HeaderEnvironProxy({
+            'HTTP_FOO': 'bar',
+            'CONTENT_LENGTH': '88',
+        })
+        r = base_sync.ProviderResponse(True, 204, headers, iter(['ab', 'cd']))
+        with self.assertRaises(ValueError) as cm:
+            r.reraise()
+        self.assertEqual(
+            'reraise had no prior exception for '
+            '<%s: %s, %r, %s, %r>' % (
+                'ProviderResponse', 'True', 204,
+                "{'Content-Length': '88', 'Foo': 'bar'}",
+                "abcd"),
+            cm.exception.message)
+
+    def test_provider_response_reraise_no_exc_info_long_body(self):
+        headers = swob.HeaderEnvironProxy({
+            'HTTP_FOO': 'bar',
+            'CONTENT_LENGTH': '88',
+        })
+        r = base_sync.ProviderResponse(True, 204, headers, iter(['A'] * 100))
+        with self.assertRaises(ValueError) as cm:
+            r.reraise()
+        self.assertEqual(
+            'reraise had no prior exception for '
+            '<%s: %s, %r, %s, %r>' % (
+                'ProviderResponse', 'True', 204,
+                "{'Content-Length': '88', 'Foo': 'bar'}",
+                ("A" * 70) + '...'),
+            cm.exception.message)

--- a/test/unit/test_sync_s3.py
+++ b/test/unit/test_sync_s3.py
@@ -589,6 +589,10 @@ class TestSyncS3(unittest.TestCase):
 
     def test_delete_object(self):
         key = 'key'
+        self.mock_boto3_client.delete_object.return_value = {
+            'DeleteMarker': False,
+            'VersionId': '',
+        }
 
         self.sync_s3.delete_object(key)
         self.mock_boto3_client.delete_object.assert_has_calls([
@@ -741,6 +745,10 @@ class TestSyncS3(unittest.TestCase):
 
         client = mock.Mock()
         session.client.return_value = client
+        client.delete_object.return_value = {
+            'DeleteMarker': False,
+            'VersionId': '',
+        }
 
         sync = SyncS3({'aws_bucket': self.aws_bucket,
                        'aws_identity': 'identity',
@@ -794,6 +802,10 @@ class TestSyncS3(unittest.TestCase):
 
                 client = mock.Mock()
                 session.client.return_value = client
+                client.delete_object.return_value = {
+                    'DeleteMarker': False,
+                    'VersionId': '',
+                }
 
                 sync = SyncS3(settings)
                 # Connections are only instantiated when there is an object to

--- a/test/unit/test_sync_swift.py
+++ b/test/unit/test_sync_swift.py
@@ -235,6 +235,7 @@ class TestSyncSwift(unittest.TestCase):
             'etag': '%s' % etag,
             'Content-Type': 'application/foo'}
         swift_client.post_object.return_value = None
+        swift_client.delete_object.return_value = None
 
         self.sync_swift.upload_object(key, storage_policy, mock_ic)
 
@@ -259,6 +260,7 @@ class TestSyncSwift(unittest.TestCase):
         swift_client.head_object.return_value = {
             'x-object-meta-old': 'old', 'etag': '%s' % etag}
         swift_client.post_object.return_value = None
+        swift_client.delete_object.return_value = None
 
         self.sync_swift.upload_object(key, storage_policy, mock_ic)
 
@@ -556,6 +558,8 @@ class TestSyncSwift(unittest.TestCase):
         mock_swift.return_value = swift_client
         # When deleting in Swift, we have to do a HEAD in case it's an SLO
         swift_client.head_object.return_value = {}
+        swift_client.delete_object.return_value = None
+
         self.sync_swift.delete_object(key)
         swift_client.delete_object.assert_called_with(
             self.aws_bucket, key, headers={})
@@ -589,6 +593,7 @@ class TestSyncSwift(unittest.TestCase):
         }
         swift_client.get_object.return_value = (
             {}, json.dumps(manifest))
+        swift_client.delete_object.return_value = None
 
         self.sync_swift.delete_object(slo_key)
 

--- a/test/unit/test_verify.py
+++ b/test/unit/test_verify.py
@@ -222,6 +222,10 @@ class TestMainTrackClientCalls(unittest.TestCase):
                 },
             },
         }
+        mock_client.delete_object.return_value = {
+            'DeleteMarker': False,
+            'VersionId': '',
+        }
         exit_arg = main([
             '--protocol', 's3',
             '--endpoint', 'https://s3.amazonaws.com',
@@ -364,6 +368,7 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ]
         mock_client.get_container.return_value = ({}, [])
         mock_client.post_object.return_value = None
+        mock_client.delete_object.return_value = None
         exit_arg = main([
             '--protocol', 'swift',
             '--endpoint', 'https://saio:8080/auth/v1.0',


### PR DESCRIPTION
local-to-me objects can now be deleted; deletes are not propagated through
to the remote-to-me Swift store.

Also make provider delete_object() return a ProviderResponse

Also also, error ProviderResponses now have a `reraise()` method which will
reraise the low-level exception from the provider's library.  This is only
used to preserve some existing behavior, but it's potentially quite useful
for debugging, especially as providers are used more by cloud-connector,
etc.