### PR TITLE
cloud-connector: automatically reload config files

### DIFF
--- a/s3_sync/cloud_connector/util.py
+++ b/s3_sync/cloud_connector/util.py
@@ -17,9 +17,58 @@ limitations under the License.
 import os
 import pwd
 import requests
+import time
 import traceback
 
 from s3_sync.sync_s3 import SyncS3
+
+
+class ConfigReloaderMixin(object):
+    """
+    Classes that need to reload one or more config files from a S3 protocol
+    object store can use this mixin to automatically reload configs when they
+    change.
+
+    Using classes can define these properties:
+        CHECK_PERIOD = X  # check for new config every X seconds
+        CONF_FILES = [{
+           'key': '...',
+           'load_cb': some_fn,
+        }, ...]
+    """
+    def reload_confs(self):
+        # The using class may need to fiddle around in __init__ to determine
+        # what the contents of CONF_FILES should be, so to avoid a
+        # chicken-and-egg in a __init__() here, we just lazily populate
+        # self.config_info in here.
+        if not getattr(self, 'config_info', None):
+            self.config_info = [{
+                'key': cf['key'],
+                'load_cb': cf['load_cb'],
+                'next_check': 0,
+                'last_etag': '',
+            } for cf in self.CONF_FILES]
+
+        now = time.time()
+        # We have to get fresh env_options to avoid trying to use an expired
+        # short-term service credential handed out by Amazon ECS.
+        # TODO(darrell): store the expire time of the ECS cred somewhere and
+        # use that to not hit the ECS cred endpoint any more frequently than we
+        # need to.
+        env_options = None
+        for ci in self.config_info:
+            if now >= ci['next_check']:
+                if not env_options:
+                    env_options = get_env_options()
+                try:
+                    resp = get_conf_file_from_s3(ci['key'], env_options,
+                                                 if_none_match=ci['last_etag'])
+                    ci['last_etag'] = resp.headers['etag']
+                    ci['load_cb'](''.join(resp.body))
+                except ConfigUnchanged:
+                    pass
+                finally:
+                    ci['next_check'] = now + self.CHECK_PERIOD
 
 
 def get_aws_ecs_creds():
@@ -93,16 +142,20 @@ class GetAndWriteFileException(Exception):
     pass
 
 
-def get_and_write_conf_file_from_s3(obj_name, target_path, env_options,
-                                    user=None):
+class ConfigUnchanged(Exception):
+    pass
+
+
+def get_conf_file_from_s3(obj_name, env_options, if_none_match=None):
     """
     Uses configuration, as read and returned by `get_env_options` to fetch an
-    object specified by name, from a S3 endpoint, and write it to the given
-    local filesystem path.
+    object specified by name, from a S3 endpoint, and return the
+    ProviderResponse object for the GET.
 
-    If a user name is specified and the current euid is 0 (running as root),
-    the written file is chown'ed to the uid and primary gid of the specified
-    user.
+    If the optional kwarg `if_none_match` is specified, it will be passed into
+    the GET (to only GET a conf file if its ETag is different than what we got
+    last time).  If the response is 304 (not modified), a ConfigUnchanged
+    exception will be raised.
     """
     provider_settings = {
         'aws_identity': env_options['AWS_ACCESS_KEY_ID'],
@@ -121,10 +174,29 @@ def get_and_write_conf_file_from_s3(obj_name, target_path, env_options,
         provider_settings['aws_session_token'] = \
             env_options['AWS_SECURITY_TOKEN_STRING']
     provider = SyncS3(provider_settings)
-    resp = provider.get_object(obj_name)
-    if not resp.success:
+    get_object_opts = {'IfNoneMatch': if_none_match} \
+        if if_none_match is not None else {}
+    resp = provider.get_object(obj_name, **get_object_opts)
+    if not resp.success and resp.status != 304:
         raise GetAndWriteFileException('GET for %s: %s %s' % (
             obj_name, resp.status, ''.join(resp.body)))
+    if resp.status == 304:
+        raise ConfigUnchanged()
+    return resp
+
+
+def get_and_write_conf_file_from_s3(obj_name, target_path, env_options,
+                                    user=None):
+    """
+    Uses configuration, as read and returned by `get_env_options` to fetch an
+    object specified by name, from a S3 endpoint, and write it to the given
+    local filesystem path.
+
+    If a user name is specified and the current euid is 0 (running as root),
+    the written file is chown'ed to the uid and primary gid of the specified
+    user.
+    """
+    resp = get_conf_file_from_s3(obj_name, env_options)
     try:
         with open(target_path, 'wb') as fh:
             if user is not None and os.geteuid() == 0:


### PR DESCRIPTION
Automatically reload updated sync or S3 DB config files in S3-api object
store.  We don't reload the main config file because there are lots of
settings in there that require a restart anyway.

Each of the c-c application class and the c-c authentication/authorization
classes inherit from ConfigReloaderMixin and define a CHECK_PERIOD property
that defines the minimum time between checks against the S3-api object
store holding the config files.  The ETag of fetched configs is cached and
used with IfNoneMatch to put the onus of detecting change on the S3-API
object store.

[#156747715]