### PR TITLE
Fix Keystone auth when using remote_account

### DIFF
--- a/containers/swift-s3-sync/Dockerfile
+++ b/containers/swift-s3-sync/Dockerfile
@@ -35,6 +35,13 @@ RUN bash -c "cd /usr/local/src \
     && patch -p0 < /tmp/swift3-unicode-fix.patch \
     && rm -f /tmp/swift3-unicode-fix.patch"
 
+# This patch allows tempauth to use Keystone-provided identities ("groups") for
+# authz decisions.
+COPY containers/swift-s3-sync/tempauth-keystone-groups.patch /tmp/
+RUN bash -c "cd /usr/local/src \
+    && patch -p0 < /tmp/tempauth-keystone-groups.patch \
+    && rm -f /tmp/tempauth-keystone-groups.patch"
+
 ENV CONF_BUCKET=cloud-connector-conf
 
 CMD ["/bin/bash", "/swift-s3-sync/containers/swift-s3-sync/launch.sh"]

--- a/containers/swift-s3-sync/swift-s3-sync.conf
+++ b/containers/swift-s3-sync/swift-s3-sync.conf
@@ -217,6 +217,36 @@
             "merge_namespaces": true,
             "propagate_delete": true,
             "retain_local": true
+        },
+        {
+            "account": "AUTH_\u062acct",
+            "container": "keystone2",
+            "aws_bucket": "keystone2",
+            "aws_endpoint": "http://1space-keystone:5000/v2.0",
+            "aws_identity": "tester",
+            "aws_secret": "testing",
+            "auth_type": "keystone_v2",
+            "tenant_name": "test",
+            "protocol": "swift",
+            "merge_namespaces": true,
+            "propagate_delete": true,
+            "retain_local": true
+        },
+        {
+            "account": "AUTH_\u062acct",
+            "container": "keystone2a",
+            "aws_bucket": "keystone2a",
+            "aws_endpoint": "http://1space-keystone:5000/v2.0",
+            "aws_identity": "tester",
+            "aws_secret": "testing",
+            "auth_type": "keystone_v2",
+            "tenant_name": "test",
+            "protocol": "swift",
+            "merge_namespaces": true,
+            "propagate_delete": false,
+            "retain_local": false,
+            "copy_after": 0,
+            "remote_account": "AUTH_\u062aacct2"
         }
     ],
     "migrations": [

--- a/containers/swift-s3-sync/tempauth-keystone-groups.patch
+++ b/containers/swift-s3-sync/tempauth-keystone-groups.patch
@@ -1,0 +1,15 @@
+diff -ru swift.orig/swift/common/middleware/tempauth.py swift/swift/common/middleware/tempauth.py
+--- swift.orig/swift/common/middleware/tempauth.py	2018-08-13 23:33:28.000000000 +0000
++++ swift/swift/common/middleware/tempauth.py	2018-08-15 18:50:05.159165000 +0000
+@@ -547,7 +547,10 @@
+                 headers = [('Content-Type', 'text/plain; charset=UTF-8')]
+                 return HTTPBadRequest(request=req, headers=headers, body=msg)
+ 
+-        user_groups = (req.remote_user or '').split(',')
++        if isinstance(req.remote_user, (list, tuple)):
++            user_groups = [g.encode('utf8') for g in req.remote_user]
++        else:
++            user_groups = (req.remote_user or '').split(',')
+         account_user = user_groups[1] if len(user_groups) > 1 else None
+ 
+         if '.reseller_admin' in user_groups and \

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -84,7 +84,7 @@ class SyncSwift(BaseSync):
             _conn = swiftclient.client.Connection(**connection_kwargs)
             if self.settings.get('remote_account'):
                 # We need to rewrite the account portion of the connection's
-                # storage URL (NOTE: this wouldn't't survive a
+                # storage URL (NOTE: this wouldn't survive a
                 # token-expiration-triggered re-auth if we didn't also jam the
                 # resulting storage-url in
                 # _conn.os_options['object_storage_url'])

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -412,7 +412,7 @@ class TestCloudSyncBase(unittest.TestCase):
         acl_dict = {'read-write': [keystone_uuid]}
         acl = format_acl(version=2, acl_dict=acl_dict)
         conn = klass.conn_for_acct(u"AUTH_\u062aacct2")
-        resp_headers, body = conn.post_account({ACCOUNT_ACL_KEY: acl})
+        conn.post_account({ACCOUNT_ACL_KEY: acl})
 
     @classmethod
     def tearDownClass(klass):


### PR DESCRIPTION
Previously, when a swift protocol mapping using "remote_account", the
storage URL would have the keystone server's hostname and port, which
won't work.

The storage URL returned by keystone is the URL that needs to be munged
to have the overridden remote_account value.

Also beefed up Keystone integration tests a bit.