### PR TITLE
metadata migrator

### DIFF
--- a/containers/swift-s3-sync/Dockerfile
+++ b/containers/swift-s3-sync/Dockerfile
@@ -21,6 +21,13 @@ EXPOSE 10080
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
+RUN useradd -M -d /tmp elastic
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.tar.gz &&\
+    tar -xvf elasticsearch-5.5.2.tar.gz && chown -R elastic elasticsearch-5.5.2
+RUN echo "network.host: 0.0.0.0" >> /elasticsearch-5.5.2/config/elasticsearch.yml
+RUN sed -i 's/-Xms2g/-Xms500m/;s/-Xmx2g/-Xmx500m/' /elasticsearch-5.5.2/config/jvm.options
+EXPOSE 9200
+
 # These patches improve Unicode handling in swiftclient, and swift3
 COPY containers/swift-s3-sync/swiftclient.patch /tmp/
 RUN bash -c "cd /usr/local/src \

--- a/containers/swift-s3-sync/launch.sh
+++ b/containers/swift-s3-sync/launch.sh
@@ -45,6 +45,9 @@ python -m s3_sync --log-level debug \
     --properties /swift-s3-sync/containers/swift-s3-sync/s3proxy.properties \
     2>&1 > /var/log/s3proxy.log &
 
+/usr/bin/sudo -u elastic /bin/bash /elasticsearch-5.5.2/bin/elasticsearch \
+    > /var/log/elasticsearch.log 2>&1 &
+
 sleep 6  # let S3Proxy start up
 
 # Set up stuff for cloud-connector

--- a/containers/swift-s3-sync/swift-s3-sync.conf
+++ b/containers/swift-s3-sync/swift-s3-sync.conf
@@ -349,6 +349,108 @@
         "process": 0,
         "log_level": "debug"
     },
+    "metadata_migrations": [
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "migration-s3",
+            "aws_endpoint": "http://swift-s3-sync:10080",
+            "aws_identity": "s3-sync-test",
+            "aws_secret": "s3-sync-test",
+            "container": "migration-s3",
+            "protocol": "s3",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "migration-swift",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "\u062aacct2:\u062auser2",
+            "aws_secret": "\u062apass2",
+            "container": "migration-swift",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "migration-swift2",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "\u062aacct2:\u062auser2",
+            "aws_secret": "\u062apass2",
+            "container": "no-auto-migration-swift-reloc",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "no-auto-acl",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "\u062aacct2:\u062auser2",
+            "aws_secret": "\u062apass2",
+            "container": "no-auto-acl",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "no-auto-versioning",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "\u062aacct2:\u062auser2",
+            "aws_secret": "\u062apass2",
+            "container": "no-auto-versioning",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "no-auto-history",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "\u062aacct2:\u062auser2",
+            "aws_secret": "\u062apass2",
+            "container": "no-auto-history",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        },
+        {
+            "account": "AUTH_nacct2",
+            "aws_bucket": "/*",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "nacct:nuser",
+            "aws_secret": "npass",
+            "protocol": "swift",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_",
+            "parse_json": true
+        },
+        {
+            "account": "AUTH_\u062aacct",
+            "aws_bucket": "flotty",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "admin:admin",
+            "aws_secret": "admin",
+            "container": "flotty",
+            "prefix": "",
+            "protocol": "swift",
+            "remote_account": "AUTH_\u062aacct2",
+            "es_hosts": "http://swift-s3-sync:9200",
+            "index_prefix": "esswift_"
+        }
+    ],
+    "metadata_migrator_settings": {
+        "items_chunk": 5,
+        "log_file": "/var/log/swift-metadata-migrator.log",
+        "poll_interval": 1,
+        "status_file": "/var/lib/swift-s3-sync/metadata_migrator.status",
+        "workers": 5,
+        "processes": 1,
+        "process": 0,
+        "log_level": "debug"
+    },
     "devices": "/swift/nodes/1/node",
     "items_chunk": 1000,
     "log_file": "/var/log/swift-s3-sync.log",

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5,7 +5,7 @@
 1space is roughly composed of four parts:
 
 1. Sync/Lifecycle
-2. Migrator
+2. Migrator (and Metadata Migrator)
 3. Shunt (Swift middleware)
 4. Cloud Connector
 
@@ -68,6 +68,15 @@ contents of the remote blob store, comparing them to the Swift contents.
 
 The migrator is implemented in
 [`migrator.py`](https://github.com/swiftstack/1space/blob/master/s3_sync/sync_container.py).
+
+#### Metadata Migrator
+
+The Metadata Migrator peforms a similar function to the migrator, but instead
+of copying remote objects to a local blob store, it indexes remote object
+metadata to a local Elasticsearch cluster.
+
+It shares much of its implementation with the migrator. You can find it in
+[`metadata_migrator.py`](https://github.com/swiftstack/1space/blob/master/s3_sync/metadata_migrator.py).
 
 ### Shunt (Swift middleware)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ By default, the following services are pubished to host operating system ports:
 1. Swift: `8080`
 1. S3Proxy: `10080`
 1. Cloud Connector: `8081`
+1. Elasticsearch: `9200`
 
 If you want to publish the services to different host ports, you can create a
 file named `port-mapping.env` in the root directory of this code tree with
@@ -117,6 +118,7 @@ other values in this format (it is sorced by a shell):
 # HOST_S3_PORT=...
 # HOST_SWIFT_PORT=...
 # HOST_CLOUD_CONNECTOR_PORT=...
+# HOST_ELASTICSEARCH_PORT=...
 ```
 
 To run the main integration test container in the background, run:
@@ -165,6 +167,15 @@ s3cmd -c /swift-s3-sync/s3cfg ls -r s3://s3-sync-test
 
 You should see two objects in the bucket.
 
+If you would like to observe the metadata migrator at work, you can use curl to
+interact with the Elasticsearch instance running in the `swift-s3-sync`
+container:
+
+```
+curl http://swift-s3-sync:9200/_cat/indices/
+curl 'http://es.swift.lab:9200/*/_search?size=10000'
+```
+
 When you're done you can always destroy the containers:
 
 ```
@@ -209,9 +220,10 @@ You can run the integration tests by running
 Non-integration test time is so low that there isn't any reason to make
 another command that only runs integration tests.
 
-The integration tests need access to a Swift cluster and some sort of an S3
-provider. Currently, they use a Docker container to provide Swift and are
-configured to talk to [S3Proxy](https://github.com/andrewgaul/s3proxy).
+The integration tests need access to a Swift cluster, some sort of an S3
+provider, and an Elasticsearch instance. Currently, they use a Docker
+container to provide Swift and Elasticsearch, and are configured to talk to
+[S3Proxy](https://github.com/andrewgaul/s3proxy).
 
 The cloud sync configuration for the tests is defined in
 `containers/swift-s3-sync/swift-s3-sync.conf`. In particular, there are mappings for S3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ requests
 python-swiftclient
 lxml
 eventlet<0.23.0
+elasticsearch>=5.0.0,<6.0.0
+git+git://github.com/swiftstack/swift-metadata-sync.git@0.0.11#egg=swift-metadata-sync

--- a/run_tests
+++ b/run_tests
@@ -16,7 +16,7 @@ unit_test_status=$?
 ./scripts/ensure_keystone_started
 
 echo Waiting for container services to start...
-docker exec swift-s3-sync timeout 40 \
+docker exec swift-s3-sync timeout 120 \
     bash -c "until s3cmd -c /swift-s3-sync/s3cfg ls s3://\$CONF_BUCKET/s3-passwd.json; do sleep 1; done"
 echo "swift-s3-sync started"
 
@@ -30,6 +30,9 @@ echo "cloud-connector started"
 docker exec 1space-keystone timeout 120 \
     bash -c 'until source openrc && openstack endpoint list|grep swift; do sleep 1; done'
 echo "keystone started"
+docker exec swift-s3-sync timeout 40 \
+    bash -c 'until echo > /dev/tcp/localhost/9200; do sleep 1; done'
+echo "elasticsearch started"
 
 # make sure we can actually authenticate using keystone
 docker exec swift-s3-sync timeout 40 \

--- a/s3_sync/metadata_migrator.py
+++ b/s3_sync/metadata_migrator.py
@@ -1,0 +1,1052 @@
+"""
+Copyright 2017 SwiftStack
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import eventlet
+import eventlet.pools
+eventlet.patcher.monkey_patch(all=True)
+
+import datetime
+import errno
+import json
+import logging
+import time
+import traceback
+import elasticsearch
+import elasticsearch.helpers
+import email.utils
+import hashlib
+
+from distutils.version import StrictVersion
+from .daemon_utils import load_swift, setup_context, setup_logger
+from .utils import (convert_to_local_headers, SWIFT_TIME_FMT,
+                    get_container_headers, RemoteHTTPError,
+                    get_sys_migrator_header,
+                    MigrationContainerStates,
+                    get_local_versioning_headers,
+                    _propagated_hdr,
+                    SYSMETA_VERSIONS_LOC, SYSMETA_VERSIONS_MODE)
+
+from swift.common.http import HTTP_NOT_FOUND, HTTP_CONFLICT
+from swift.common.internal_client import UnexpectedResponse
+from swift.common.utils import Timestamp
+from .migrator import (UploadObjectWork, MigrationError,
+                       ContainerNotFound, _create_x_timestamp_from_hdrs,
+                       Status, Migrator)
+from swift_metadata_sync.metadata_sync import MetadataSync
+from .sync_s3 import SyncS3
+
+LOGGER_NAME = 'swift-metadata-migrator'
+
+
+def diff_container_headers(remote_headers, local_headers):
+    # remote_headers are unicode, local are str returns str
+    rem_headers = dict([(k.encode('utf8'), v.encode('utf8')) for k, v in
+                        remote_headers.items() if _propagated_hdr(k)])
+    rem_headers.update(get_local_versioning_headers(remote_headers))
+
+    matching_keys = set(rem_headers.keys()).intersection(local_headers.keys())
+    missing_remote_keys = set(
+        local_headers.keys()).difference(rem_headers.keys())
+
+    missing_local_keys = set(
+        rem_headers.keys()).difference(local_headers.keys())
+
+    # TODO: we can probably sink some of these checks into the
+    # _propagated_hdr() function.
+    versioning_headers = [SYSMETA_VERSIONS_LOC, SYSMETA_VERSIONS_MODE]
+    return dict([(k, rem_headers[k])
+                 for k in matching_keys if
+                 rem_headers[k] != local_headers.get(k)] +
+                [(k, rem_headers[k]) for k in missing_local_keys] +
+                [(k, None) for k in missing_remote_keys
+                 if _propagated_hdr(k) or k in versioning_headers])
+
+
+class MetadataMigratorConfigError(Exception):
+    pass
+
+
+class MetadataMigrator(Migrator):
+    '''List and index object metadata from a remote store into an Elasticsearch
+    cluster'''
+
+    def __init__(self, *args, **kwargs):
+        super(MetadataMigrator, self).__init__(*args, **kwargs)
+
+    def _head_internal_account(self, internal_client):
+        return
+
+    def _process_account_metadata(self):
+        return
+
+    def _update_container_headers(self, container, internal_client, headers):
+        req = internal_client.set_container_metadata(
+            self.config, self.config['account'], container, headers)
+
+        resp = req.get_response()
+        if resp.status_int // 100 != 2:
+            raise UnexpectedResponse('Failed to update container headers for '
+                                     '"%s": %d' % (container, resp.status_int),
+                                     resp)
+
+        self.logger.info('Updated headers for container "%s"' % container)
+
+    def _create_container(self, container, internal_client, aws_bucket,
+                          timeout=1):
+        if self.config.get('protocol') == 'swift':
+            try:
+                headers = get_container_headers(self.provider, aws_bucket)
+            except RemoteHTTPError as e:
+                if e.resp.status == 404:
+                    raise ContainerNotFound(
+                        self.config['aws_identity'], aws_bucket)
+                else:
+                    raise
+        else:
+            headers = {}
+
+        headers[get_sys_migrator_header('container')] =\
+            MigrationContainerStates.MIGRATING
+
+        req = internal_client.create_container(self.config,
+                                               self.config['account'],
+                                               container, headers)
+        resp = req.get_response()
+        if resp.status_int // 100 != 2:
+            raise UnexpectedResponse('Failed to create container "%s": %d' % (
+                container, resp.status_int), resp)
+
+        start = time.time()
+        while time.time() - start < timeout:
+            if not internal_client.container_exists(
+                    self.config,
+                    self.config['account'], container):
+                time.sleep(0.1)
+            else:
+                self.logger.info('Created container "%s"' % container)
+                return
+        raise MigrationError('Timeout while creating container "%s"' %
+                             container)
+
+    def _iterate_internal_listing(
+            self, container=None, marker='', prefix=None):
+        '''Iterate Elasticsearch indices as if they were Swift containers, or
+        iterate Elasticsearch documents as if they were objects'''
+
+        while True:
+            with self.ic_pool.item() as ic:
+                return ic.es_iter_items(self.config, self.config['account'],
+                                        container, marker, prefix)
+
+    def _reconcile_deleted_objects(self, container, key):
+        # NOTE: to handle the case of objects being deleted from the source
+        # cluster after they've been migrated, we have to HEAD the object to
+        # check for the migration header.
+        with self.ic_pool.item() as ic:
+            try:
+                hdrs = ic.get_object_metadata(self.config,
+                                              self.config['account'],
+                                              container, key)
+            except UnexpectedResponse as e:
+                # This may arise if there an eventual consistency issue between
+                # the container database and the object server state.
+                if e.resp.status_int == HTTP_NOT_FOUND:
+                    return
+                raise
+            if get_sys_migrator_header('object') in hdrs:
+                headers = {}
+                xts = hdrs.get('x-backend-durable-timestamp') or \
+                    hdrs.get('x-backend-timestamp') or hdrs.get('x-timestamp')
+                if xts:
+                    ts = Timestamp(xts)
+                    headers['x-timestamp'] = Timestamp(
+                        ts.timestamp, ts.offset + 1).internal
+                else:
+                    xts = _create_x_timestamp_from_hdrs(hdrs)
+                    if xts:
+                        headers['x-timestamp'] = Timestamp(xts, 1)
+                try:
+                    ic.delete_object(self.config, self.config['account'],
+                                     container, key, headers)
+                    self.logger.info(
+                        'Detected removed object %s. Removing from %s/%s' % (
+                            key, self.config['account'], container))
+                except UnexpectedResponse as e:
+                    if e.resp.status_int == HTTP_CONFLICT:
+                        self.logger.info(
+                            'Conflict removing object %s from %s/%s' % (
+                                key, self.config['account'], container))
+                        return
+                    raise
+
+    def _maybe_delete_internal_container(self, container):
+        '''Delete a specified internal container.
+
+        Unfortunately, we cannot simply DELETE every object in the container,
+        but have to issue a HEAD request to make sure the migrator header is
+        not set. This makes clearing containers expensive and we hope that this
+        is not a common operation.
+        '''
+        try:
+            with self.ic_pool.item() as ic:
+                headers = ic.get_container_metadata(self.config,
+                                                    self.config['account'],
+                                                    container)
+        except UnexpectedResponse as e:
+            if e.resp.status_int == HTTP_NOT_FOUND:
+                self.logger.info('Container %s/%s already removed' %
+                                 (self.config['account'], container))
+                return
+
+            self.logger.error('Failed to delete container "%s/%s"' %
+                              (self.config['account'], container))
+            self.logger.error(''.join(traceback.format_exc()))
+            return
+
+        state = headers.get(get_sys_migrator_header('container'))
+        if not state:
+            self.logger.debug(
+                'Not removing container %s/%s: created by a client.' %
+                (self.config['account'], container))
+            return
+        if state == MigrationContainerStates.SRC_DELETED:
+            return
+
+        listing = self._iterate_internal_listing(container)
+        for obj in listing:
+            if not obj:
+                break
+            self._reconcile_deleted_objects(container, obj['name'])
+
+        state_meta = {get_sys_migrator_header('container'):
+                      MigrationContainerStates.SRC_DELETED}
+        with self.ic_pool.item() as ic:
+            if state == MigrationContainerStates.MIGRATING:
+                try:
+                    ic.delete_container(self.config,
+                                        self.config['account'], container)
+                except UnexpectedResponse as e:
+                    if e.resp.status_int == HTTP_CONFLICT:
+                        # NOTE: failing to DELETE the container is OK if there
+                        # are objects in it. It means that there were write
+                        # operations outside of the migrator.
+                        ic.set_container_metadata(self.config,
+                                                  self.config['account'],
+                                                  container, state_meta)
+            else:
+                ic.set_container_metadata(self.config,
+                                          self.config['account'],
+                                          container, state_meta)
+
+    # We only propagate metadata for large object manifests, not object
+    # segments.
+    def _check_large_objects(self, aws_bucket, container, key, client):
+        return
+
+    def _process_container(
+            self, container=None, aws_bucket=None, marker=None, prefix=None,
+            list_all=False):
+        if aws_bucket is None:
+            aws_bucket = self.config['aws_bucket']
+        if container is None:
+            container = self.config['container']
+        if marker is None:
+            state = self.status.get_migration(self.config)
+            marker = state.get('marker', '')
+        if prefix is None:
+            prefix = self.config.get('prefix', '')
+        # The metadata migrator makes no special allowances for history
+        # (be it x-versions-location or x-history-location).
+        if self.config.get('protocol') == 'swift':
+            resp = self.provider.head_bucket(aws_bucket)
+            if resp.status == 404:
+                raise ContainerNotFound(
+                    self.config['aws_identity'], aws_bucket)
+            if resp.status != 200:
+                raise MigrationError(
+                    'Failed to HEAD bucket/container "%s"' % container)
+            local_headers = None
+            with self.ic_pool.item() as ic:
+                try:
+                    local_headers = ic.get_container_metadata(
+                        self.config, self.config['account'], container)
+                except UnexpectedResponse as e:
+                    if e.resp.status_int == HTTP_NOT_FOUND:
+                        # TODO: this makes one more HEAD request to fetch
+                        # headers. We should re-use resp.headers here
+                        # (appropriately converted to handle versioning)
+                        self._create_container(container, ic, aws_bucket)
+                    else:
+                        raise
+                if resp.headers and local_headers:
+                    local_ts = _create_x_timestamp_from_hdrs(
+                        local_headers, use_x_timestamp=False)
+                    remote_ts = _create_x_timestamp_from_hdrs(
+                        resp.headers, use_x_timestamp=False)
+                    header_changes = {}
+
+                    if local_ts is not None and remote_ts is not None and \
+                            local_ts < remote_ts:
+                        header_changes = diff_container_headers(
+                            resp.headers, local_headers)
+
+                    migrator_header = get_sys_migrator_header('container')
+                    if local_headers.get(migrator_header) ==\
+                            MigrationContainerStates.SRC_DELETED:
+                        header_changes[migrator_header] =\
+                            MigrationContainerStates.MODIFIED
+
+                    if header_changes:
+                        self._update_container_headers(
+                            container, ic, header_changes)
+        else:  # Not swift
+            with self.ic_pool.item() as ic:
+                if not ic.container_exists(self.config,
+                                           self.config['account'], container):
+                    self._create_container(container, ic, aws_bucket)
+
+        return self._find_missing_objects(container, aws_bucket, marker,
+                                          prefix, list_all)
+
+    def _migrate_object(self, aws_bucket, container, key):
+        args = {'bucket': aws_bucket}
+        resp = self.provider.head_object(key, **args)
+        if resp.status != 200:
+            resp.body.close()
+            raise MigrationError('Failed to HEAD "%s/%s": %s %s' % (
+                aws_bucket, key, resp.body))
+
+        put_headers = convert_to_local_headers(
+            resp.headers.items(), remove_timestamp=False)
+        work = UploadObjectWork(
+            container, key, None, put_headers,
+            aws_bucket)
+        self._upload_object(work)
+
+    def _upload_object(self, work):
+        container, key, content, headers, aws_bucket = work
+        headers['x-timestamp'] = Timestamp(
+            _create_x_timestamp_from_hdrs(headers)).internal
+        headers[get_sys_migrator_header('object')] = headers['x-timestamp']
+        with self.ic_pool.item() as ic:
+            try:
+                ic.upload_object(self.config,
+                                 content, self.config['account'],
+                                 container, key, headers)
+                self.logger.debug('Copied "%s/%s"' % (container, key))
+            except UnexpectedResponse as e:
+                if e.resp.status_int != 404:
+                    raise
+                self._create_container(container, ic, aws_bucket)
+                ic.upload_object(self.config,
+                                 content, self.config['account'],
+                                 container, key, headers)
+                self.logger.debug('Copied "%s/%s"' % (container, key))
+        self.gthread_local.uploaded_objects += 1
+        self.gthread_local.bytes_copied += 0
+
+
+def process_migrations(migrations, migration_status, internal_pool, logger,
+                       items_chunk, workers, node_id, nodes):
+    handled_containers = []
+    for index, migration in enumerate(migrations):
+        if migration['aws_bucket'] == '/*' or index % nodes == node_id:
+            # If 'all buckets' is specified, we handle index creation ourselves
+            # and only allow the user to specify an index prefix.
+            if 'index_prefix' not in migration:
+                raise MetadataMigratorConfigError(
+                    "Config error: index_prefix" +
+                    "not provided. When indexing all remote buckets, you " +
+                    "must provide an index prefix to use when creating " +
+                    "Elasticsearch indices.")
+            if migration.get('remote_account'):
+                src_account = migration.get('remote_account')
+            else:
+                src_account = migration['aws_identity']
+            logger.info('Processing "%s"' % (
+                ':'.join([migration.get('aws_endpoint', ''),
+                          src_account, migration['aws_bucket']])))
+            migrator = MetadataMigrator(migration, migration_status,
+                                        items_chunk, workers,
+                                        internal_pool, logger,
+                                        node_id, nodes)
+            pass_containers = migrator.next_pass()
+            if pass_containers is None:
+                # Happens if there is an error listing containers.
+                # Inserting the migration we attempted to process will ensure
+                # we don't prune it (or the related containers).
+                handled_containers.append(migration)
+            else:
+                handled_containers += pass_containers
+            migrator.close()
+    migration_status.prune(handled_containers)
+
+
+def run(metadata_migrations, migration_status, internal_pool, logger,
+        items_chunk, workers, node_id, nodes, poll_interval, once):
+    while True:
+        cycle_start = time.time()
+        process_migrations(metadata_migrations, migration_status,
+                           internal_pool, logger,
+                           items_chunk, workers, node_id, nodes)
+        elapsed = time.time() - cycle_start
+        naptime = max(0, poll_interval - elapsed)
+        msg = 'Finished cycle in %0.2fs' % elapsed
+        if once:
+            logger.info(msg)
+            return
+        msg += ', sleeping for %0.2fs.' % naptime
+        logger.info(msg)
+        time.sleep(naptime)
+
+
+def create_ic_pool(config, swift_dir, workers, logger):
+    return eventlet.pools.Pool(
+        create=lambda: create_es_client(config, swift_dir, logger),
+        min_size=0,
+        max_size=workers + 1)  # Our enumerating thread uses a client as well.
+
+
+def create_es_client(config, swift_dir, logger):
+    return ESInternalClient(config, swift_dir, logger)
+
+
+class ESUnexpectedResponse(UnexpectedResponse):
+    def __init__(self, response):
+        self.response = self.resp = response
+
+    def __repr__(self):
+        return repr(self.response)
+
+    def __str__(self):
+        return str(self.response)
+
+
+class ESInternalClientResponse(object):
+    def __init__(self, status_int, headers={}, body={}):
+        self.status_int = status_int
+        self.headers = headers
+        self.body = body
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return "ESInternalClientResponse: status %s, headers %s, body %s" % (
+            self.status_int, self.headers, self.body)
+
+
+class ESInternalClientRequest(object):
+    def __init__(self, response_status_int, response_headers={},
+                 response_body={}):
+        self.response = ESInternalClientResponse(response_status_int,
+                                                 response_headers,
+                                                 response_body)
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return "ESInternalClientRequest: Response:  %s" % str(self.response)
+
+    def get_response(self):
+        return self.response
+
+
+class ESInternalClient(object):
+    '''Provide a swift internal-client-like Elasticsearch connection'''
+
+    DOC_TYPE = MetadataSync.DOC_TYPE
+    DOC_MAPPING = MetadataSync.DOC_MAPPING
+    USER_META_PREFIX = MetadataSync.USER_META_PREFIX
+    INDEX_MAX_LENGTH = 255
+    INDEX_INVALID_CHARS = ['#', "\\" '/', '*', '?', '"', '<', '>', '|']
+    SWIFT_PAGINATION_LIMIT = 10000
+    _es_conns = {}
+
+    def __init__(self, config, swift_dir, logger):
+        self.config = dict(config)
+        self._verified_indices = {}
+        self.logger = logger
+
+    def __str__(self):
+        return str(self.config)
+
+    def _verifies_mapping(fn):
+        def wrapper(self, config, account, container, *args, **kwargs):
+            index = self._get_es_index(config, account, container)
+            index_pattern = "%s:%s" % (config['es_hosts'], index)
+            try:
+                self._verified_indices[index_pattern]
+            except KeyError:
+                self._verify_mapping(config, index)
+                self._verified_indices[index_pattern] = True
+            return fn(self, config, account, container, *args, **kwargs)
+        return wrapper
+
+    def make_request(
+            self, method, path, headers, acceptable_statuses, body_file=None,
+            params=None):
+        raise NotImplementedError
+
+    def get_object_metadata(self, config, account, container, key):
+        _id = self._get_document_id(account, container, key)
+
+        try:
+            resp = self._get_es_conn(config).get(
+                index=self._get_es_index(config, account, container),
+                doc_type=self.DOC_TYPE,
+                id=_id
+            )
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+
+        self.logger.debug("ESInternalClient: Retrieved ES document " +
+                          "metadata %s for %s/%s" % (
+                              resp, self._get_es_index(
+                                  config, account, container), key))
+        return self._es_to_object_store(resp)
+
+    def delete_object(self, config, account, container, key, headers={}):
+        _id = self._get_document_id(account, container, key)
+
+        try:
+            self._get_es_conn(config).delete(
+                index=self._get_es_index(config, account, container),
+                doc_type=self.DOC_TYPE,
+                id=_id)
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+
+        self.logger.debug("ESInternalClient: Deleted ES document %s/%s" % (
+            self._get_es_index(config, account, container), key))
+        return True
+
+    def upload_object(self, config, content, account, container, key, headers):
+        try:
+            self._create_index_op(config, account, container, key, headers)
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+        self.logger.debug("ESInternalClient: Indexed ES document %s/%s" % (
+            self._get_es_index(config, account, container), key))
+        return True
+
+    def create_container(self, config, account, container, headers={}):
+        properties = dict([(k, v) for k, v in
+                          ESInternalClient.DOC_MAPPING.items()])
+        if self._get_server_version(config) >= StrictVersion('5.0'):
+            properties = dict([(k, self._update_string_mapping(v))
+                              for k, v in properties.items()])
+        new_mapping = {
+            'mappings': {
+                self.DOC_TYPE: {
+                    'properties': properties,
+                    '_meta': headers
+                }
+            }
+        }
+
+        try:
+            self._get_es_conn(config).indices.create(
+                index=self._get_es_index(config, account, container),
+                body=new_mapping)
+        except Exception as e:
+            return self._es_exception_as_request(e)
+
+        self.logger.debug("ESInternalClient: Created ES index %s" % (
+            self._get_es_index(config, account, container)))
+        return ESInternalClientRequest(200)
+
+    def container_exists(self, config, account, container):
+        try:
+            return bool(self._get_es_conn(config).indices.exists(
+                index=self._get_es_index(config, account, container)))
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+
+    def get_container_metadata(self, config, account, container):
+        try:
+            mappings = self._get_es_conn(config).indices.get_mapping(
+                index=self._get_es_index(config, account, container))
+            self.logger.debug("ESInternalClient: Retrieved metadata mapping " +
+                              " %s for ES index %s" % (
+                                  mappings, self._get_es_index(
+                                      config, account, container)))
+            return (mappings[self._get_es_index(config, account, container)]
+                            ['mappings'][self.DOC_TYPE].get('_meta', {}))
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+
+    def delete_container(self, config, account, container):
+        try:
+            self._get_es_conn(config).indices.delete(
+                index=self._get_es_index(config, account, container))
+            self.logger.debug("ESInternalClient: Deleted ES index %s" % (
+                self._get_es_index(config, account, container)))
+            return ESInternalClientRequest(200)
+        except Exception as e:
+            raise ESUnexpectedResponse(self._es_exception_as_response(e))
+
+    # Replaces, rather than updates, the _meta properties for a given index
+    def set_container_metadata(self, config, account, container, headers):
+        try:
+            mappings = self._get_es_conn(config).indices.get_mapping(
+                index=self._get_es_index(config, account, container),
+                doc_type=self.DOC_TYPE)
+        except Exception as e:
+            return self._es_exception_as_request(e)
+
+        cleaned_headers = {k: v for (k, v) in headers.items()
+                           if v is not None}
+        mapping = (mappings[self._get_es_index(config, account, container)]
+                   ['mappings'][self.DOC_TYPE])
+        mapping['_meta'] = cleaned_headers
+
+        try:
+            self._get_es_conn(config).indices.put_mapping(
+                index=self._get_es_index(config, account, container),
+                doc_type=self.DOC_TYPE,
+                body=mapping)
+            self.logger.debug("ESInternalClient: Updated meta for index " +
+                              "%s with %s" % (
+                                  self._get_es_index(
+                                      config, account, container), headers))
+            return ESInternalClientRequest(200)
+        except Exception as e:
+            return self._es_exception_as_request(e)
+
+    def set_account_metadata(self, account, headers):
+        return ESInternalClientRequest(200)
+
+    def _get_es_conn(self, config, item='conn'):
+        try:
+            return ESInternalClient._es_conns[config['es_hosts']][item]
+        except KeyError:
+            verify_certs = config.get('verify_certs', True)
+            ca_certs = config.get('ca_certs')
+            es_conn = elasticsearch.Elasticsearch(
+                config['es_hosts'],
+                verify_certs=verify_certs,
+                ca_certs=ca_certs
+            )
+            server_version = StrictVersion(
+                es_conn.info()['version']['number'])
+            ESInternalClient._es_conns[config['es_hosts']] = {
+                'conn': es_conn,
+                'server_version': server_version}
+
+            self.logger.debug("ESInternalClient: Connected to ES at " +
+                              " %s (server version %s" %
+                              (config['es_hosts'], server_version))
+
+            return es_conn
+
+    def _get_server_version(self, config):
+        return self._get_es_conn(config, item='server_version')
+
+    def _get_es_index(self, config, account, container):
+        return self._get_es_index_prefix(config, account, container=container)
+
+    def _get_es_index_prefix(self, config, account, container=''):
+        try:
+            index_prefix = config['index_prefix']
+        except KeyError:
+            return self._maybe_decode(config['index'])
+
+        index = "%s%s_%s" % (
+            self._maybe_decode(index_prefix),
+            self._maybe_decode(account),
+            self._maybe_decode(container))
+        index = index.lower()
+        for i in self.INDEX_INVALID_CHARS:
+            index = index.replace(i, '_')
+        if len(index) > self.INDEX_MAX_LENGTH:
+            index = (index[:self.INDEX_MAX_LENGTH])
+
+        return self._maybe_decode(index)
+
+    def _es_exception_as_response(self, exception):
+        return self._es_exception_as_request(exception).response
+
+    def _es_exception_as_request(self, exception):
+        if type(exception) is elasticsearch.ImproperlyConfigured:
+            return ESInternalClientRequest(
+                400, {}, "Elasticsearch client is improperly configured")
+        elif type(exception) is elasticsearch.SerializationError:
+            return ESInternalClientRequest(
+                422, {}, "Client passed improperly serialized data")
+        elif type(exception) is elasticsearch.TransportError:
+            if exception.status_code is not 'N/A':
+                return ESInternalClientRequest(
+                    exception.status_code, {}, exception.error)
+            else:
+                return ESInternalClientRequest(
+                    502, {}, "Could not connect to Elasticsearch")
+        elif type(exception) is elasticsearch.ConnectionError:
+            return ESInternalClientRequest(
+                502, {}, "Connection to Elasticsearch failed: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.ConnectionTimeout:
+            return ESInternalClientRequest(
+                502, {}, "Connection to Elasticsearch timed out: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.SSLError:
+            return ESInternalClientRequest(
+                502, {}, "TLS Error communicating with Elasticsearch: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.NotFoundError:
+            return ESInternalClientRequest(
+                404, {}, "Entity not found in Elasticsearch")
+        elif type(exception) is elasticsearch.ConflictError:
+            return ESInternalClientRequest(
+                409, {}, "Elasticsearch replied with 409 conflict")
+        elif type(exception) is elasticsearch.RequestError:
+            return ESInternalClientRequest(
+                400, {}, "Elasticsearch replied with 400 bad request")
+        else:
+            return ESInternalClientRequest(
+                502, {}, "Unknown Elasticsearch error: %s" % (
+                    str(exception)))
+
+    def es_iter_items(self, config, account, container=None, marker=None,
+                      prefix=None):
+        if container is None:
+            return self._es_iter_containers(config, account, marker, prefix)
+        else:
+            return self._es_iter_objects(config, account, container,
+                                         marker, prefix)
+
+    def _es_iter_containers(self, config, account, marker=None, _prefix=''):
+        if _prefix is None:
+            prefix = ''
+
+        indices = None
+        while True:
+            index_prefix = "%s%s*" % (self._get_es_index_prefix(
+                                      config, account), prefix)
+            if not indices:
+                try:
+                    indices = sorted(self._get_es_conn(config)
+                                         .indices.get("%s" % (
+                                             index_prefix)).keys())
+                except Exception as e:
+                    raise ESUnexpectedResponse(
+                        self._es_exception_as_response(e))
+
+            if not indices:
+                break
+
+            index = 0
+            if marker:
+                try:
+                    index = indices.index(marker) + 1
+                except ValueError:
+                    pass
+                try:
+                    indices[index]
+                except IndexError:
+                    break
+
+            for entry in indices[index:index + self.SWIFT_PAGINATION_LIMIT]:
+                marker = entry
+                yield {'name': entry[len(index_prefix) - 1:]}
+
+        yield None
+
+    def _es_iter_objects(self, config, account, container=None, marker=None,
+                         prefix=None):
+        while True:
+            body = {
+                "sort": [{"x-swift-object.keyword": {"order": "asc"}}],
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"match": {"x-swift-account":
+                                       account.encode('utf-8')}},
+                            {"match": {"x-swift-container":
+                                       container.encode('utf-8')}},
+                            {"exists": {"field": "x-swift-object"}}
+                        ]
+                    }
+                }
+            }
+
+            if marker:
+                body['search_after'] = [marker]
+            self.logger.debug("Searching, search_after marker is %s" % marker)
+
+            try:
+                resp = self._get_es_conn(config).search(
+                    index=self._get_es_index(config, account, container),
+                    doc_type=self.DOC_TYPE,
+                    size=self.SWIFT_PAGINATION_LIMIT,
+                    body=body)
+            except Exception as e:
+                self.logger.error("ES document iteration for index %s " %
+                                  self._get_es_index(
+                                      config, account, container) +
+                                  " raised exception %s" % e)
+                break
+
+            if not resp:
+                break
+
+            if 'hits' not in resp:
+                break
+
+            if 'hits' not in resp['hits']:
+                break
+
+            if not resp['hits']['hits']:
+                break
+
+            for entry in resp['hits']['hits']:
+                yield self._es_to_object_store(entry)
+
+            marker = resp['hits']['hits'][-1]['sort'][0].encode('utf-8')
+        yield None
+
+    def _es_to_object_store(self, item):
+        n = {
+            'hash': item['_source']['etag'],
+            'name': item['_source']['x-swift-object'],
+            'content_type': item['_source']['content-type'],
+            'bytes': item['_source']['content-length']}
+
+        if 'last-modified' in item['_source']:
+            n['last_modified'] = datetime.datetime.utcfromtimestamp(
+                int(int(item['_source']['last-modified']) / 1000)
+            ).strftime(SWIFT_TIME_FMT)
+
+        if get_sys_migrator_header('object') in item['_source']:
+            n[get_sys_migrator_header('object')] = \
+                item['_source'][get_sys_migrator_header('object')]
+
+        if 'content-location' in item['_source']:
+            n['content-location'] = item['_source']['content-location']
+
+        return n
+
+    def _maybe_decode(self, string):
+        _string = string if isinstance(
+            string, unicode) else string.decode('utf-8')
+        return _string
+
+    def _maybe_encode(self, string):
+        _string = string if not isinstance(
+            string, unicode) else string.encode('utf-8')
+        return _string
+
+    def _make_content_location(self, config):
+        if config.get('protocol', '') == 's3':
+            location_prefix = 'AWS S3'
+            if config.get('aws_endpoint', '') == SyncS3.GOOGLE_API:
+                location_prefix = 'Google Cloud Storage'
+            location_parts = [location_prefix, config.get('aws_bucket', '')]
+            location_parts.append(config.get('prefix', ''))
+            content_location = ';'.join(location_parts)
+        else:
+            u_ident = config['aws_identity'] if isinstance(
+                config['aws_identity'], unicode) else \
+                config['aws_identity'].decode('utf8')
+            endpoint = config.get('endpoint', '')
+            if not endpoint:
+                endpoint = 'swift'
+            content_location = '%s;%s;%s' % (
+                endpoint,
+                u_ident, config.get('aws_bucket', ''))
+        return content_location
+
+    @_verifies_mapping
+    def _create_index_op(self, config, account, container, key, headers):
+        meta = headers
+        meta['content-location'] = self._make_content_location(config)
+
+        op = self._get_es_conn(config).index(
+            index=self._get_es_index(config, account, container),
+            doc_type=self.DOC_TYPE,
+            body=self._create_es_doc(meta, account,
+                                     container,
+                                     self._maybe_decode(key),
+                                     config.get('parse_json', False)),
+            id=self._get_document_id(account, container, key),
+            pipeline=config.get('pipeline', None))
+
+        self.logger.debug("ESInternalClient: Created ES document %s/%s" % (
+            self._get_es_index(config, account, container), key))
+
+        return op
+
+    def _get_document_id(self, account, container, key):
+        ret = hashlib.sha256(
+            '/'.join(
+                [account.encode('utf-8'),
+                 container.encode('utf-8'),
+                 key.encode('utf-8')])).hexdigest()
+        return ret
+
+    """
+        Verify document mapping for the elastic search index. Does not include
+        any user-defined fields.
+    """
+    def _verify_mapping(self, config, index):
+        index_client = self._get_es_conn(config).indices
+
+        try:
+            mapping = index_client.get_mapping(
+                index=index,
+                doc_type=self.DOC_TYPE)
+        except elasticsearch.TransportError as e:
+            if e.status_code != 404:
+                raise
+            if e.error != 'type_missing_exception':
+                raise
+            mapping = {}
+        if not mapping.get(index, None) or \
+                self.DOC_TYPE not in (
+                    mapping[index]['mappings']):
+            missing_fields = self.DOC_MAPPING.keys()
+        else:
+            current_mapping = (mapping[index]
+                               ['mappings']
+                               [self.DOC_TYPE]['properties'])
+            # We are not going to force re-indexing, so won't be checking the
+            # mapping format
+            missing_fields = [key for key in self.DOC_MAPPING.keys()
+                              if key not in current_mapping]
+        if missing_fields:
+            new_mapping = dict([(k, v) for k, v in self.DOC_MAPPING.items()
+                                if k in missing_fields])
+            # Elasticsearch 5.x deprecated the "string" type. We convert the
+            # string fields into the appropriate 5.x types.
+            # TODO: Once we remove  support for the 2.x clusters, we should
+            # remove this code and create the new mappings for each field.
+            if self._get_server_version(config) >= StrictVersion('5.0'):
+                new_mapping = dict([(k, self._update_string_mapping(v))
+                                    for k, v in new_mapping.items()])
+            index_client.put_mapping(index=index, doc_type=self.DOC_TYPE,
+                                     body={'properties': new_mapping})
+        self.logger.debug("ESInternalClient: Verified ES mapping for " +
+                          "index %s" % index)
+
+    @staticmethod
+    def _update_string_mapping(mapping):
+        if mapping['type'] != 'string':
+            return mapping
+        if 'index' in mapping and mapping['index'] == 'not_analyzed':
+            return {'type': 'keyword'}
+        # This creates a mapping that is both searchable as a text and keyword
+        # (the default  behavior in Elasticsearch for 2.x string types).
+        return {
+            'type': 'text',
+            'fields': {
+                'keyword': {
+                    'type': 'keyword'}
+            }
+        }
+
+    @staticmethod
+    def _create_es_doc(_meta, account, container, key, parse_json=False):
+        def _parse_document(value):
+            try:
+                return json.loads(value.decode('utf-8'))
+            except ValueError:
+                return value.decode('utf-8')
+
+        # Content-Length ends up capitalised
+        meta = {k.lower(): v for k, v in _meta.items()}
+
+        es_doc = {}
+        # ElasticSearch only supports millisecond resolution;
+        # we also add the migrator header to our index
+        es_doc[get_sys_migrator_header('object')] = \
+            es_doc['x-timestamp'] = \
+            int(float(meta['x-timestamp']) * 1000)
+
+        # Convert Last-Modified header into a millis since epoch date
+        ts = email.utils.mktime_tz(
+            email.utils.parsedate_tz(meta['last-modified'])) * 1000
+        es_doc['last-modified'] = ts
+        es_doc['x-swift-object'] = key
+        es_doc['x-swift-account'] = account
+        es_doc['x-swift-container'] = container
+
+        if 'content-location' in meta:
+            es_doc['content-location'] = meta['content-location']
+
+        user_meta_keys = dict(
+            [(k.split(ESInternalClient.USER_META_PREFIX, 1)[1].decode('utf-8'),
+              _parse_document(v) if parse_json else v.decode('utf-8'))
+             for k, v in meta.items()
+             if k.startswith(ESInternalClient.USER_META_PREFIX)])
+        es_doc.update(user_meta_keys)
+        for field in ESInternalClient.DOC_MAPPING.keys():
+            if field in es_doc:
+                continue
+            if field not in meta:
+                continue
+            if ESInternalClient.DOC_MAPPING[field]['type'] == 'boolean':
+                es_doc[field] = str(meta[field]).lower()
+                continue
+            es_doc[field] = meta[field]
+        return es_doc
+
+
+def main():
+    args, conf = setup_context(
+        description='Daemon to migrate object metadata into Elasticsearch')
+    if 'metadata_migrator_settings' not in conf:
+        print 'Missing metadata migrator settings section'
+        exit(-1)
+
+    migrator_conf = conf['metadata_migrator_settings']
+    if 'status_file' not in migrator_conf:
+        print 'Missing status file location!'
+        exit(-1 * errno.ENOENT)
+
+    if args.log_level:
+        migrator_conf['log_level'] = args.log_level
+    migrator_conf['console'] = args.console
+
+    handler = setup_logger(LOGGER_NAME, migrator_conf)
+    logger = logging.getLogger('s3_sync')
+    logger.addHandler(handler)
+
+    load_swift(LOGGER_NAME, args.once)
+
+    logger = logging.getLogger(LOGGER_NAME)
+
+    workers = migrator_conf.get('workers', 10)
+    swift_dir = conf.get('swift_dir', '/etc/swift')
+    internal_pool = create_ic_pool(conf, swift_dir, workers, logger)
+
+    if 'process' not in migrator_conf or 'processes' not in migrator_conf:
+        print 'Missing "process" or "processes" settings in the config file'
+        exit(-1)
+
+    items_chunk = migrator_conf['items_chunk']
+    node_id = int(migrator_conf['process'])
+    nodes = int(migrator_conf['processes'])
+    poll_interval = float(migrator_conf.get('poll_interval', 5))
+
+    migrations = conf.get('metadata_migrations', [])
+    migration_status = Status(migrator_conf['status_file'])
+    run(migrations, migration_status, internal_pool, logger, items_chunk,
+        workers, node_id, nodes, poll_interval, args.once)
+
+
+if __name__ == '__main__':
+    main()

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -157,6 +157,19 @@ class S3SyncShunt(object):
                    profile['container'].encode('utf-8'))
             self.sync_profiles[key] = profile
 
+        for migration in conf.get('metadata_migrations', []):
+            profile = dict(migration)
+            # Migrations should have some sane defaults if they aren't present
+            profile.setdefault('restore_object', False)
+            profile.setdefault('container', profile['aws_bucket'])
+            profile.setdefault('migration', True)
+            # if, in the future, we support custom_prefix on the S3 side,
+            # we may need to change this. Swift side code ignores custom_prefix
+            profile['custom_prefix'] = ''
+            key = (profile['account'].encode('utf-8'),
+                   profile['container'].encode('utf-8'))
+            self.sync_profiles[key] = profile
+
     def __call__(self, env, start_response):
         if time() > self._rtime:
             self._reload()
@@ -305,6 +318,7 @@ class S3SyncShunt(object):
 
     def handle_listing(self, req, start_response, sync_profile, cont,
                        per_account):
+
         limit, marker, prefix, delimiter, path = get_list_params(
             req, constraints.CONTAINER_LISTING_LIMIT)
 

--- a/scripts/rebuild_and_start_main_container
+++ b/scripts/rebuild_and_start_main_container
@@ -11,6 +11,7 @@ cd "$MYDIR"/..
 # HOST_S3_PORT=...
 # HOST_SWIFT_PORT=...
 # HOST_CLOUD_CONNECTOR_PORT=...
+# HOST_ELASTICSEARCH_PORT=...
 test -f ./port-mapping.env && . ./port-mapping.env
 
 # This will be fast if the image is up-to-date and cached:
@@ -30,4 +31,5 @@ docker run -d -v `pwd`:/swift-s3-sync \
     --network swift-s3-sync-net --network-alias swift-s3-sync \
     -p "${HOST_S3_PORT:-10080}:10080" \
     -p "${HOST_SWIFT_PORT:-8080}:8080" \
+    -p "${HOST_ELASTICSEARCH_PORT:-9200}:9200" \
     swift-s3-sync

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='swift-s3-sync',
               'swift-s3-verify = s3_sync.verify:main',
               'swift-s3-migrator = s3_sync.migrator:main',
               'cloud-connector = s3_sync.cloud_connector.app:main',
+              'swift-metadata-migrator = s3_sync.metadata_migrator:main',
           ],
           'paste.filter_factory': [
               'cloud-shunt = s3_sync.shunt:filter_factory',

--- a/test/integration/test_metadata_migrator.py
+++ b/test/integration/test_metadata_migrator.py
@@ -1,0 +1,1256 @@
+"""
+Copyright 2018 SwiftStack
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import boto3
+import botocore
+import botocore.exceptions
+from contextlib import contextmanager
+from functools import partial
+import hashlib
+import json
+import StringIO
+import swiftclient
+from swiftclient.exceptions import ClientException
+import time
+import urllib
+from . import (
+    clear_swift_container, wait_for_condition,
+    clear_s3_bucket, clear_swift_account, kill_a_pid)
+import s3_sync.daemon_utils
+import s3_sync.migrator
+import s3_sync.metadata_migrator
+from s3_sync.migrator import get_sys_migrator_header
+from s3_sync.utils import SWIFT_TIME_FMT
+from swift_metadata_sync.metadata_sync import MetadataSync
+import elasticsearch
+import test_migrator
+import logging
+import psutil
+import subprocess
+import datetime
+import re
+import mock
+
+
+LAST_MODIFIED_FMT = '%a, %d %b %Y %H:%M:%S %Z'
+
+
+def is_metadata_migrator_running():
+    """
+    Returns the PID of a running metadata migrator, or a false value otherwise.
+    """
+    for proc in psutil.process_iter():
+        try:
+            if '/usr/local/bin/swift-metadata-migrator' in proc.cmdline():
+                return proc.pid
+        except Exception:
+            pass
+
+
+class TempMetadataMigratorStatus(object):
+    def __init__(self, config):
+        self.config = config
+        self.status = {}
+
+    def save_migration(self, config, marker, copied, scanned, bytes_count,
+                       is_reset):
+        self.status['marker'] = marker
+        s3_sync.migrator._update_status_counts(
+            self.status, copied, scanned, bytes_count, is_reset)
+
+    def get_migration(self, config):
+        # Currently, we only support a single migration configuration
+        if not s3_sync.migrator.equal_migration(self.config, config):
+            raise NotImplementedError
+        return self.status
+
+
+class MetadataMigratorFactory(object):
+    CONFIG = '/swift-s3-sync/containers/swift-s3-sync/swift-s3-sync.conf'
+    SWIFT_DIR = '/etc/swift'
+
+    def __init__(self, conf_path=CONFIG):
+        with open(conf_path) as conf_fh:
+            self.config = json.load(conf_fh)
+        self.migrator_config = self.config['metadata_migrator_settings']
+        s3_sync.daemon_utils.setup_logger(
+            s3_sync.metadata_migrator.LOGGER_NAME, self.migrator_config)
+        self.logger = logging.getLogger(s3_sync.metadata_migrator.LOGGER_NAME)
+
+    def get_migrator(self, migration, status):
+        ic_pool = s3_sync.metadata_migrator.create_ic_pool(
+            self.config, self.SWIFT_DIR, self.migrator_config['workers'] + 1,
+            self.logger)
+        return s3_sync.metadata_migrator.MetadataMigrator(
+            migration, status, self.migrator_config['items_chunk'],
+            self.migrator_config['workers'], ic_pool, self.logger, 0, 1)
+
+
+class ESClientException(ClientException):
+    def __init__(self, status_code, headers, message):
+        self.status_code = status_code
+        self.headers = status_code
+        self.message = message
+        super(ESClientException, self).__init__(
+            message,
+            http_status=status_code,
+            http_response_headers=headers,
+            http_response_content=message)
+
+    @classmethod
+    def from_response(*args, **kwargs):
+        raise NotImplementedError
+
+    def __str__(self):
+        return "Elasticsearch response: %s: %s" % (
+            self.status_code, self.message)
+
+
+class SwiftLikeESConnection(object):
+
+    DOC_TYPE = MetadataSync.DOC_TYPE
+    SWIFT_PAGINATION_LIMIT = 10000
+    DOC_MAPPING = MetadataSync.DOC_MAPPING
+    USER_META_PREFIX = MetadataSync.USER_META_PREFIX
+    INDEX_MAX_LENGTH = 255
+    INDEX_INVALID_CHARS = ['#', "\\" '/', '*', '?', '"', '<', '>', '|']
+
+    def __init__(self, account, mapping_config, **kwargs):
+        self.logger = logging.getLogger()
+        self._config = mapping_config
+        self.account = account
+        self._es_conn = elasticsearch.Elasticsearch(
+            mapping_config['es_hosts'])
+
+    def _maybe_decode(self, string):
+        s = string.decode('utf8') if not isinstance(string, unicode)\
+            else string
+        return s
+
+    def _maybe_encode(self, string):
+        s = string.encode('utf8') if isinstance(string, unicode)\
+            else string
+        return s
+
+    def _get_es_index(self, container):
+        return self._get_es_index_prefix(container=container)
+
+    def _get_es_index_prefix(self, container=''):
+        try:
+            index_prefix = self._config['index_prefix']
+        except KeyError:
+            return self._maybe_decode(self._config['index'])
+
+        index = "%s%s_%s" % (
+            self._maybe_decode(index_prefix),
+            self._maybe_decode(self.account),
+            self._maybe_decode(container))
+        index = index.lower()
+        for i in self.INDEX_INVALID_CHARS:
+            index = index.replace(i, '_')
+        if len(index) > self.INDEX_MAX_LENGTH:
+            index = (index[:self.INDEX_MAX_LENGTH])
+        return index
+
+    def _es_exception_as_clientexception(self, exception):
+        if type(exception) is elasticsearch.ImproperlyConfigured:
+            return ESClientException(
+                400, {}, "Elasticsearch client is improperly configured")
+        elif type(exception) is elasticsearch.SerializationError:
+            return ESClientException(
+                422, {}, "Client passed improperly serialized data")
+        elif type(exception) is elasticsearch.TransportError:
+            if exception.status_code is not 'N/A':
+                return ESClientException(
+                    exception.status_code, {}, exception.error)
+            else:
+                return ESClientException(
+                    502, {}, "Could not connect to Elasticsearch")
+        elif type(exception) is elasticsearch.ConnectionError:
+            return ESClientException(
+                502, {}, "Connection to Elasticsearch failed: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.ConnectionTimeout:
+            return ESClientException(
+                502, {}, "Connection to Elasticsearch timed out: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.SSLError:
+            return ESClientException(
+                502, {}, "TLS Error communicating with Elasticsearch: %s" % (
+                    str(exception)))
+        elif type(exception) is elasticsearch.NotFoundError:
+            return ESClientException(
+                404, {}, "Entity not found in Elasticsearch")
+        elif type(exception) is elasticsearch.ConflictError:
+            return ESClientException(
+                409, {}, "Elasticsearch replied with 409 conflict")
+        elif type(exception) is elasticsearch.RequestError:
+            return ESClientException(
+                400, {}, "Elasticsearch replied with 400 bad request")
+        else:
+            return ESClientException(
+                502, {}, "Unknown Elasticsearch error: %s" % (
+                    str(exception)))
+
+    def _es_to_object_store(self, item):
+        n = {
+            'hash': item['_source'].get('etag', ''),
+            'name': item['_source']['x-swift-object'],
+            'content_type': item['_source'].get('content-type', ''),
+            'bytes': item['_source'].get('content-length', '')}
+
+        if 'last-modified' in item['_source']:
+            n['last_modified'] = datetime.datetime.utcfromtimestamp(
+                int(int(item['_source']['last-modified']) / 1000)
+            ).strftime(SWIFT_TIME_FMT)
+
+        if get_sys_migrator_header('object') in item['_source']:
+            n[get_sys_migrator_header('object')] = \
+                item['_source'][get_sys_migrator_header('object')]
+
+        if 'content-location' in item['_source']:
+            n['content_location'] = item['_source']['content-location']
+
+        return n
+
+    def _es_to_object_store_headers(self, item):
+        n = {
+            'etag': item['_source'].get('etag', ''),
+            'name': item['_source']['x-swift-object'],
+            'content-type': item['_source'].get('content-type', ''),
+            'content-length': item['_source'].get('content-length', '')}
+
+        if 'last-modified' in item['_source']:
+            n['last-modified'] = datetime.datetime.utcfromtimestamp(
+                int(int(item['_source']['last-modified']) / 1000)
+            ).strftime(SWIFT_TIME_FMT)
+
+        if get_sys_migrator_header('object') in item['_source']:
+            n[get_sys_migrator_header('object')] = \
+                item['_source'][get_sys_migrator_header('object')]
+
+        if 'content-location' in item['_source']:
+            n['content-location'] = item['_source']['content-location']
+
+        non_user_meta = ['etag', 'x-swift-object', 'x-swift-account',
+                         'x-swift-container', 'content-type', 'content-length',
+                         'last-modified', 'content-location']
+        for k, v in item['_source'].items():
+            if k not in non_user_meta:
+                n["x-object-meta-%s" % k] = v
+
+        return n
+
+    def _get_document_id(self, container, key):
+        return hashlib.sha256(
+            '/'.join([self._maybe_encode(self.account),
+                      self._maybe_encode(container),
+                      self._maybe_encode(key)])
+        ).hexdigest()
+
+    def _create_es_doc(self, _meta, container, key, parse_json=False):
+        def _parse_document(value):
+            try:
+                return json.loads(value.decode('utf-8'))
+            except ValueError:
+                return value.decode('utf-8')
+
+        meta = {k.lower(): v for k, v in _meta.items()}
+        es_doc = {}
+
+        ts = int(time.time() * 1000)
+        es_doc['last-modified'] = ts
+        es_doc['x-swift-object'] = key
+        es_doc['x-swift-account'] = self.account
+        es_doc['x-swift-container'] = container
+
+        if 'content-location' in meta:
+            es_doc['content-location'] = meta['content-location']
+
+        user_meta_keys = dict(
+            [(k.split(SwiftLikeESConnection.USER_META_PREFIX, 1)[1].
+              decode('utf-8'),
+             _parse_document(v) if parse_json else v.decode('utf-8'))
+             for k, v in meta.items()
+             if k.startswith(SwiftLikeESConnection.USER_META_PREFIX)])
+        es_doc.update(user_meta_keys)
+        for field in SwiftLikeESConnection.DOC_MAPPING.keys():
+            if field in es_doc:
+                continue
+            if field not in meta:
+                continue
+            if SwiftLikeESConnection.DOC_MAPPING[field]['type'] == 'boolean':
+                es_doc[field] = str(meta[field]).lower()
+                continue
+            es_doc[field] = meta[field]
+        return es_doc
+
+    @staticmethod
+    def _update_string_mapping(mapping):
+        if mapping['type'] != 'string':
+            return mapping
+        if 'index' in mapping and mapping['index'] == 'not_analyzed':
+            return {'type': 'keyword'}
+        # This creates a mapping that is both searchable as a text and keyword
+        # (the default  behavior in Elasticsearch for 2.x string types).
+        return {
+            'type': 'text',
+            'fields': {
+                'keyword': {
+                    'type': 'keyword'}
+            }
+        }
+
+    def delete_container(self, container):
+        try:
+            self._es_conn.indices.delete(
+                index=self._get_es_index(container))
+        except Exception as e:
+            if hasattr(e, 'status_code') and e.status_code == 404:
+                pass
+            else:
+                raise self._es_exception_as_clientexception(e)
+
+    def delete_object(self, container, obj):
+        _id = self._get_document_id(container, obj)
+
+        try:
+            self._es_conn.delete(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE,
+                id=_id)
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+    def get_account(self):
+        index_prefix = "%s*" % self._get_es_index_prefix()
+
+        try:
+            indices = sorted(self._es_conn
+                                 .indices.get("%s" % (
+                                     index_prefix)).keys())
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+        def lreplace(s, old, new):
+            return re.sub(r'^(?:%s)+' % re.escape(old),
+                          lambda m: new * (m.end() / len(old)),
+                          s)
+        return (
+            {},
+            [{'name': lreplace(index,
+             self._get_es_index_prefix(), '')}
+             for index in indices])
+
+    def get_container(self, container):
+        body = {
+            "sort": [{"x-swift-object.keyword": {"order": "asc"}}],
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"match":
+                            {"x-swift-account":
+                                self._maybe_encode(self.account)}},
+                        {"match":
+                            {"x-swift-container":
+                                self._maybe_encode(container)}},
+                        {"exists": {"field": "x-swift-object"}}
+                    ]
+                }
+            }
+        }
+
+        headers = self.head_container(container)
+
+        try:
+            resp = self._es_conn.search(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE,
+                size=self.SWIFT_PAGINATION_LIMIT,
+                body=body)
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+        if not resp:
+            return (headers, [])
+
+        hits = resp.get('hits', {}).get('hits', [])
+        entries = [self._es_to_object_store(entry) for entry in hits]
+        result = (headers, entries)
+        return result
+
+    def get_object(self, container, key):
+        hdrs = self.head_object(container, key)
+        # The metadata migrator only respects some sysmeta
+        # headers, none of which are content-disposition,
+        # content-encoding, or x-delete-at.
+        # To shim some migrator tests we need to mock these out.
+        hdrs['content-disposition'] = mock.ANY
+        hdrs['content-encoding'] = mock.ANY
+        hdrs['x-delete-at'] = mock.ANY
+        # Also mock the body
+        return (hdrs, mock.ANY)
+
+    # No equivalent in ES.
+    def head_account(self):
+        raise NotImplementedError
+
+    def head_container(self, container):
+        try:
+            mappings = self._es_conn.indices.get_mapping(
+                index=self._get_es_index(container))
+            return (mappings[self._get_es_index(container)]
+                            ['mappings'][self.DOC_TYPE].get(
+                                '_meta', {}))
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+    def head_object(self, container, key):
+        _id = self._get_document_id(container, key)
+
+        try:
+            resp = self._es_conn.get(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE,
+                id=_id
+            )
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+        return self._es_to_object_store_headers(resp)
+
+    def post_account(self, headers):
+        raise NotImplementedError
+
+    def post_container(self, container, headers):
+        try:
+            mappings = self._es_conn.indices.get_mapping(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE)
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+        mapping = mappings[
+            self._get_es_index(container)
+        ]['mappings'][self.DOC_TYPE]
+
+        try:
+            mapping['_meta'].update(headers)
+        except KeyError:
+            mapping['_meta'] = headers
+
+        mapping['_meta']['last-modified'] =\
+            time.strftime(LAST_MODIFIED_FMT)
+
+        (mappings[self._get_es_index(container)]
+            ['mappings'][self.DOC_TYPE]
+            ['_meta']).update(headers)
+        try:
+            self._es_conn.indices.put_mapping(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE,
+                body=mapping)
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+    def post_object(self, container, key, headers):
+        headers['etag'] = 'deadbeef'
+        headers['content-length'] = 0
+        headers['content-type'] = 'application/foo'
+        try:
+            self._create_es_doc(headers,
+                                container,
+                                self._maybe_decode(key),
+                                self._config.get('parse_json',
+                                                 False))
+            # Force-refresh the index to avoid consistency
+            # issues with "X newer than Y" type tests.
+            self._es_conn.index(
+                index=self._get_es_index(container),
+                doc_type=self.DOC_TYPE,
+                body=self._create_es_doc(headers,
+                                         container,
+                                         self._maybe_decode(key),
+                                         self._config.get(
+                                             'parse_json', False)),
+                id=self._get_document_id(container, key),
+                pipeline=self._config.get('pipeline', None),
+                refresh=True)
+        except Exception as e:
+            raise self._es_exception_as_clientexception(e)
+
+    def put_container(self, container, headers=None):
+        properties = dict([(k, v) for k, v in
+                          SwiftLikeESConnection.DOC_MAPPING.items()])
+        properties = dict([(k, self._update_string_mapping(v))
+                          for k, v in properties.items()])
+        new_mapping = {
+            'mappings': {
+                self.DOC_TYPE: {
+                    'properties': properties,
+                    '_meta': headers
+                }
+            }
+        }
+
+        new_mapping['mappings'][self.DOC_TYPE]['_meta']['last-modified'] =\
+            time.strftime(LAST_MODIFIED_FMT)
+
+        try:
+            self._es_conn.indices.create(
+                index=self._get_es_index(container),
+                body=new_mapping)
+        except Exception as e:
+            try:
+                if not e.info['error']['type'] ==\
+                        'index_already_exists_exception':
+                    raise self._es_exception_as_clientexception(e)
+            except (KeyError, AttributeError, ValueError) as e:
+                raise self._es_exception_as_clientexception(e)
+
+    def put_object(self, container, key, body, headers={}):
+        return self.post_object(container, key, headers)
+
+
+class TestMetadataMigrator(test_migrator.TestMigrator):
+
+    conn_by_acct_es = {}  # Connections by account, for elasticsearch
+
+    # We can reuse many, but not all migrator tests by just
+    # swapping out our 'local' and / or 'noshunt' swift connections
+    # with a swift-like elasticsearch connection.
+    # In some cases we need to retain the 'local', shunted connection
+    # so we can test the shunt.
+    _es_shims = {'conn_for_acct': [], 'conn_for_acct_noshunt': []}
+
+    @classmethod
+    def conn_for_acct(klass, acct):
+        if acct in TestMetadataMigrator._es_shims['conn_for_acct']:
+            return TestMetadataMigrator.conn_for_acct_es(acct)
+        else:
+            return test_migrator.TestMigrator.conn_for_acct(acct)
+
+    @classmethod
+    def conn_for_acct_noshunt(klass, acct):
+        if acct in TestMetadataMigrator._es_shims['conn_for_acct_noshunt']:
+            return TestMetadataMigrator.conn_for_acct_es(acct)
+        else:
+            return test_migrator.TestMigrator.conn_for_acct_noshunt(acct)
+
+    def local_swift(self, method, *args, **kwargs):
+        if TestMetadataMigrator._es_shims.get('local_swift', False):
+            return self.local_es(method, *args, **kwargs)
+        else:
+            return getattr(self.swift_src, method)(*args, **kwargs)
+
+    @classmethod
+    def _add_conn_for_elastic_acct(klass, mapping, acct_utf8, mapping_config):
+        if acct_utf8 not in mapping:
+            mapping[acct_utf8] =\
+                SwiftLikeESConnection(acct_utf8, mapping_config)
+
+    @classmethod
+    def _add_conns_for_elastic_acct(klass, acct_utf8, mapping_config):
+        klass._add_conn_for_elastic_acct(
+            klass.conn_by_acct_es, acct_utf8, mapping_config)
+
+    @classmethod
+    def _get_s3_sync_conf(klass):
+        with open(klass.CLOUD_SYNC_CONF) as conf_handle:
+            conf = json.load(conf_handle)
+            conf['migrations'] = conf['metadata_migrations']
+            conf['migrator_settings'] = conf['metadata_migrator_settings']
+            return conf
+
+    @classmethod
+    def _find_migration(klass, matcher):
+        for migration in klass.test_conf['metadata_migrations']:
+            if matcher(migration):
+                return migration
+        raise RuntimeError('No matching metadata migration')
+
+    @classmethod
+    def conn_for_acct_es(klass, acct):
+        acct_utf8 = acct.encode('utf-8') if isinstance(acct, unicode) else acct
+        try:
+            return klass.conn_by_acct_es[acct_utf8]
+        except KeyError:
+            raise
+
+    def local_es(self, method, *args, **kwargs):
+        return getattr(self.es_src, method)(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(klass):
+        TestMetadataMigrator._es_shims = \
+            {'conn_for_acct': [], 'conn_for_acct_noshunt': []}
+        klass.test_conf = klass._get_s3_sync_conf()
+
+        # Get a reseller_admin token so we don't have to mess with any auth
+        # silliness.
+        klass.admin_conn = swiftclient.client.Connection(
+            klass.SWIFT_CREDS['authurl'],
+            klass.SWIFT_CREDS['admin']['user'],
+            klass.SWIFT_CREDS['admin']['key'],
+            retries=0)
+        _, admin_token = klass.admin_conn.get_auth()
+
+        # Get our s3 client biz
+        s3 = [container for container in klass.test_conf['containers']
+              if container.get('protocol', 's3') == 's3'][0]
+        klass.S3_CREDS.update({
+            'endpoint': 'http://localhost:%d' % klass.PORTS['s3'],
+            'user': s3['aws_identity'],
+            'key': s3['aws_secret'],
+        })
+        session = boto3.session.Session(
+            aws_access_key_id=s3['aws_identity'],
+            aws_secret_access_key=s3['aws_secret'])
+        conf = boto3.session.Config(s3={'addressing_style': 'path'})
+        klass.s3_client = session.client(
+            's3', config=conf,
+            endpoint_url='http://localhost:%d' % klass.PORTS['s3'])
+
+        url_user_key_to_acct = {}  # temporary for deduping account lookups
+        for mapping in klass.test_conf['migrations']:
+            # Make sure we have a connection for any Swift account on either
+            # "end".  For remote ends, we have to auth once to find the account
+            # name; we use url_user_key_to_acct to only do that once per input
+            # tuple that could give us different answers.
+            acct_utf8 = mapping['account'].encode('utf8')
+            klass._add_conns_for_elastic_acct(acct_utf8, mapping)
+            klass._add_conns_for_swift_acct(acct_utf8, admin_token)
+
+            if mapping['protocol'] == 'swift':
+                # Get conns for the other side, too
+                if mapping.get('remote_account'):
+                    acct_utf8 = mapping['remote_account'].encode('utf8')
+                else:
+                    conn_key = (mapping['aws_endpoint'],
+                                mapping['aws_identity'],
+                                mapping['aws_secret'])
+                    acct_utf8 = url_user_key_to_acct.get(conn_key)
+                if not acct_utf8:
+                    connection_kwargs = {
+                        'authurl': mapping['aws_endpoint'],
+                        'user': mapping['aws_identity'],
+                        'key': mapping['aws_secret'],
+                        'retries': 0
+                    }
+
+                    if mapping.get('auth_type') == 'keystone_v3':
+                        connection_kwargs['os_options'] = {
+                            'project_name': mapping.get('project_name'),
+                            'user_domain_name': mapping.get(
+                                'user_domain_name'),
+                            'project_domain_name':
+                            mapping.get('project_domain_name')
+                        }
+                        connection_kwargs['auth_version'] = '3'
+
+                    # Need to auth to get acct name, then add it to the cache
+                    conn = swiftclient.client.Connection(**connection_kwargs)
+                    url, _ = conn.get_auth()
+                    acct_utf8 = urllib.unquote(url.rsplit('/')[-1])
+                    url_user_key_to_acct[conn_key] = acct_utf8
+                klass._add_conns_for_swift_acct(acct_utf8, admin_token)
+                klass._add_conns_for_elastic_acct(acct_utf8, mapping)
+                # As a convenience for ourselves, we'll stick the resolved
+                # remote Swift account name in the mapping as "aws_account"
+                # (stored as Unicode string for consistency)
+                # TODO(darrell): maybe use `remote_account` since the
+                # SwiftSync() class can eat that already, so there's precedent
+                # for the storage key name.
+                mapping['aws_account'] = acct_utf8.decode('utf8')
+
+            # Now maybe auto-create some containers
+            if mapping.get('aws_bucket') == '/*':
+                continue
+            if container['aws_bucket'].startswith('no-auto-'):
+                # Remove any no-auto create containers for swift
+                if mapping['protocol'] == 'swift':
+                    try:
+                        conn = klass.conn_for_acct_noshunt(
+                            mapping['aws_account'])
+                        conn.delete_container(mapping['aws_bucket'])
+                    except swiftclient.exceptions.ClientException as e:
+                        if e.http_status == 404:
+                            continue
+                        raise
+            else:
+                if mapping['protocol'] == 'swift' and \
+                        mapping.get('aws_bucket'):
+                    # For now, the aws_bucket is just a prefix, not a container
+                    # name for a swift destination that has a source container
+                    # of /*.  So don't create a container of that name.
+                    if mapping.get('container') != '/*':
+                        conn = klass.conn_for_acct_noshunt(
+                            mapping['aws_account'])
+                        conn.put_container(mapping['aws_bucket'])
+                else:
+                    try:
+                        klass.s3_client.create_bucket(
+                            Bucket=mapping['aws_bucket'])
+                    except botocore.exceptions.ClientError as e:
+                        if e.response['Error']['Code'] == 409:
+                            pass
+            if mapping.get('container') and mapping.get('container') != '/*':
+                conn = klass.conn_for_acct_noshunt(mapping['account'])
+                if mapping['container'].startswith('no-auto-'):
+                    try:
+                        clear_swift_container(conn, mapping['container'])
+                        conn.delete_container(mapping['container'])
+                    except swiftclient.exceptions.ClientException as e:
+                        if e.http_status != 404:
+                            raise
+                else:
+                    conn.put_container(mapping['container'])
+
+        klass.swift_src = klass.conn_for_acct('AUTH_test')
+        klass.es_src = klass.conn_for_acct_es('AUTH_test')
+        klass.swift_dst = klass.conn_for_acct(
+            u"AUTH_\u062aacct2".encode('utf8'))
+        klass.swift_nuser = klass.conn_for_acct('AUTH_nacct')
+        klass.es_nuser = klass.conn_for_acct('AUTH_nacct')
+        klass.swift_nuser2 = klass.conn_for_acct('AUTH_nacct2')
+        klass.es_nuser2 = klass.conn_for_acct('AUTH_nacct2')
+        # We actually test auth through this connection, so give it real creds:
+        klass.cloud_connector_client = swiftclient.Connection(
+            'http://cloud-connector:%d/auth/v1.0' %
+            klass.PORTS['cloud_connector'],
+            klass.SWIFT_CREDS['cloud-connector']['user'],
+            klass.SWIFT_CREDS['cloud-connector']['key'],
+            retries=0)
+
+        klass.es_src = klass.conn_for_acct_es('AUTH_test')
+        klass.es_dst = klass.conn_for_acct_es(
+            u"AUTH_\u062aacct2".encode('utf8'))
+        klass.es_nuser = klass.conn_for_acct_es('AUTH_nacct')
+        klass.es_nuser2 = klass.conn_for_acct_es('AUTH_nacct2')
+
+    @contextmanager
+    def migrator_running(self):
+        """
+        Context manager that starts the migrator and then ensures it gets
+        stopped when the context is exited.
+        """
+        old_migrator_pid = is_metadata_migrator_running()
+        if old_migrator_pid:
+            kill_a_pid(old_migrator_pid)
+
+        devnull = open('/dev/null', 'wb')
+        proc = subprocess.Popen(
+            ['/usr/bin/python', '/usr/local/bin/swift-metadata-migrator',
+             '--config',
+             '/swift-s3-sync/containers/swift-s3-sync/swift-s3-sync.conf'],
+            close_fds=True,
+            cwd='/',
+            stdout=devnull, stderr=devnull)
+        try:
+            yield
+        finally:
+            devnull.close()
+            if proc.poll() is None:
+                kill_a_pid(proc.pid)
+
+    def tearDown(self):
+        TestMetadataMigrator._es_shims = \
+            {'conn_for_acct': [], 'conn_for_acct_noshunt': []}
+
+        def _clear_and_maybe_delete_container(account, container):
+            for conn in [self.conn_for_acct_noshunt(account),
+                         self.conn_for_acct_es(account)]:
+                clear_swift_container(conn, container)
+                clear_swift_container(conn, container + '_segments')
+                if container.startswith('no-auto-'):
+                    try:
+                        conn.delete_container(container)
+                        conn.delete_container(container + '_segments')
+                    except swiftclient.exceptions.ClientException as e:
+                        if e.http_status != 404:
+                            raise
+
+        # Make sure all migration-related containers are cleared
+        for container in self.test_conf['migrations']:
+            if container.get('container'):
+                _clear_and_maybe_delete_container(container['account'],
+                                                  container['container'])
+            if container['aws_bucket'] == '/*':
+                continue
+            if container['protocol'] == 'swift':
+                _clear_and_maybe_delete_container(container['aws_account'],
+                                                  container['aws_bucket'])
+            else:
+                try:
+                    clear_s3_bucket(self.s3_client, container['aws_bucket'])
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] == 'NoSuchBucket':
+                        continue
+
+        # Clean out all container accounts
+        clear_swift_account(self.swift_nuser)
+        clear_swift_account(self.swift_nuser2)
+        clear_swift_account(self.es_nuser)
+        clear_swift_account(self.es_nuser2)
+
+    def test_s3_migration(self):
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [],
+            'conn_for_acct_noshunt': [],
+            'local_swift': True}
+        return super(TestMetadataMigrator, self).\
+            test_s3_migration()
+
+    def test_swift_migration(self):
+        migration = self.swift_migration()
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_swift_migration()
+
+    def test_swift_migration_unicode_acct(self):
+        migration = self._find_migration(
+            lambda m: m.get('container') == 'flotty')
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_swift_migration_unicode_acct()
+
+    def test_swift_large_objects(self):
+        migration = self.swift_migration()
+        conn_es = self.conn_for_acct_es(migration['account'])
+        status = TempMetadataMigratorStatus(migration)
+        migrator = MetadataMigratorFactory().get_migrator(
+            migration, status)
+
+        segments_container = migration['aws_bucket'] + '_segments'
+
+        self.remote_swift(
+            'put_container', segments_container)
+        for i in range(10):
+            self.remote_swift('put_object', segments_container,
+                              'slo-part-%d' % i, chr(97 + i) * 2**20,
+                              headers={'x-object-meta-part': i})
+            self.remote_swift('put_object', segments_container,
+                              'dlo-part-%d' % i, chr(97 + i) * 2**20,
+                              headers={'x-object-meta-part': i})
+        # Upload the manifests
+        self.remote_swift(
+            'put_object', migration['aws_bucket'], 'dlo', '',
+            headers={'x-object-manifest': segments_container + '/dlo-part',
+                     'x-object-meta-dlo': 'dlo-meta'})
+
+        slo_manifest = [
+            {'path': '/%s/slo-part-%d' % (segments_container, i)}
+            for i in range(10)]
+        self.remote_swift(
+            'put_object', migration['aws_bucket'], 'slo',
+            json.dumps(slo_manifest),
+            headers={'x-object-meta-slo': 'slo-meta'},
+            query_string='multipart-manifest=put')
+
+        migrator.next_pass()
+
+        # Allow ES just enough time to refresh the index.
+        # The metadata migrator won't try to do anything with the segments.
+        time.sleep(2)
+        _, listing = conn_es.get_container(migration['container'])
+        swift_names = [obj['name'] for obj in listing]
+        objects = ['dlo', 'slo']
+        self.assertEqual(sorted(objects), swift_names)
+
+    def test_swift_self_contained_dlo(self):
+        # Metadata migrator doesn't care about large object segments.
+        pass
+
+    def test_migrate_new_container_location(self):
+        migration = self._find_migration(
+            lambda cont: cont['container'] == 'no-auto-migration-swift-reloc')
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_migrate_new_container_location()
+
+    def test_container_meta(self):
+        migration = self._find_migration(
+            lambda cont: cont['container'] == 'no-auto-acl')
+
+        acl = 'AUTH_' + migration['aws_identity'].split(':')[0]
+        self.remote_swift('put_container', migration['aws_bucket'],
+                          headers={'x-container-read': acl,
+                                   'x-container-write': acl,
+                                   'x-container-meta-test': 'test metadata'})
+
+        conn_local = self.conn_for_acct(migration['account'])
+        conn_es = self.conn_for_acct_es(migration['account'])
+
+        def _check_container_created(conn):
+            try:
+                ret = conn.get_container(migration['container'])
+                if ret:
+                    return ret
+            except swiftclient.exceptions.ClientException as e:
+                if e.http_status == 404:
+                    return False
+                raise
+
+        # verify get_head works through shunt
+        hdrs = conn_local.head_container(migration['container'])
+        self.assertIn('x-container-meta-test', hdrs)
+        self.assertEqual('test metadata', hdrs['x-container-meta-test'])
+
+        # Verify get_container works through shunt
+        res = _check_container_created(conn_local)
+        self.assertTrue(res)
+        hdrs, listing = res
+        self.assertIn('x-container-meta-test', hdrs)
+        self.assertEqual('test metadata', hdrs['x-container-meta-test'])
+
+        # verify container not really there
+        self.assertFalse(_check_container_created(conn_es))
+
+        with self.migrator_running():
+            hdrs, listing = wait_for_condition(5, partial(
+                _check_container_created, conn_es))
+
+        self.assertIn('x-container-meta-test', hdrs)
+        self.assertEqual('test metadata', hdrs['x-container-meta-test'])
+
+    def test_migrate_all_containers(self):
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+        test_objects = [
+            ('swift-blobBBB2', 'blob content', {}),
+            (u'swift-2unicod\u00e9', '\xde\xad\xbe\xef', {}),
+            ('swift-2with-headers',
+             'header-blob',
+             {'x-object-meta-custom-header': 'value',
+              u'x-object-meta-unicod\u00e9': u'\u262f',
+              u'x-object-meta-parse-json': '["foo", "bar"]',
+              u'x-object-meta-parse-json-unicod\u00e9':
+                  u'["foo\u262f", "\u262f"]',
+              'content-type': 'migrator/test'})]
+
+        test_containers = ['container1', 'container2', 'container3',
+                           u'container-\u062a']
+
+        conn_es = self.conn_for_acct_es(migration['account'])
+        conn_local = self.conn_for_acct(migration['account'])
+        conn_remote = self.conn_for_acct(migration['aws_account'])
+
+        def _check_objects_copied():
+            test_names = set([obj[0] for obj in test_objects])
+            for cont in test_containers:
+                try:
+                    hdrs, listing = conn_es.get_container(cont)
+                except swiftclient.exceptions.ClientException as ce:
+                    if '404' in str(ce):
+                        return False
+                    else:
+                        raise
+                swift_names = set([obj['name'] for obj in listing])
+                if test_names != swift_names:
+                    return False
+            return True
+
+        for i, container in enumerate(test_containers):
+            container_meta = {
+                u'x-container-meta-tes\u00e9t': u'test\u262f metadata%d' % i}
+            conn_remote.put_container(
+                # We create a new dictionary, because SwiftClient mutates the
+                # header dictionary that we pass it, unfortunately.
+                test_containers[i], headers=dict(container_meta))
+            # verify get_head works through shunt
+            hdrs = conn_local.head_container(test_containers[i])
+            for key, value in container_meta.items():
+                self.assertIn(key, hdrs)
+                self.assertEqual(value, hdrs[key])
+
+            for name, body, headers in test_objects:
+                conn_remote.put_object(
+                    container, name, StringIO.StringIO(body), headers=headers)
+
+        with self.migrator_running():
+            wait_for_condition(5, _check_objects_copied)
+
+        for name, expected_body, user_meta in test_objects:
+            for cont in test_containers:
+                hdrs = conn_es.head_object(cont, name)
+                for k, v in user_meta.items():
+                    self.assertIn(k, hdrs)
+                    if 'parse-json' in k:
+                        self.assertEqual(
+                            json.loads(v.encode('utf-8')),
+                            hdrs[k])
+                    else:
+                        self.assertEqual(v, hdrs[k])
+
+    def test_propagate_delete(self):
+        # We don't propagate deletes.
+        pass
+
+    def test_propagate_container_meta(self):
+        # Nor do we propagate container meta.
+        pass
+
+    def test_migrate_account_metadata(self):
+        # ...and we don't migrate account metadata as we don't have
+        # an equivalent structure to an "account" in ES, only a container
+        # (which is represented as an entire index).
+        pass
+
+    def test_propagate_container_meta_changes(self):
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+
+        acl = 'AUTH_' + self.SWIFT_CREDS['dst']['user'].split(':')[0]
+
+        key1 = u'x-container-meta-migrated-\u062a'
+        key2 = u'x-container-meta-migrated-2-\u062a'
+        key3 = u'x-container-meta-migrated-3-\u062a'
+        val1 = u'new-meta \u062a'
+        val2 = u'changed-meta \u062a'
+        val3 = u'new-meta2 \u062a'
+
+        init_local_headers = {
+            key2: val2,
+            key3: val1,
+        }
+        init_remote_headers = {
+            'x-container-write': acl,
+            'x-container-read': acl,
+            key1: val1,
+            key3: val3,
+        }
+
+        conn_es = self.conn_for_acct_es(migration['account'])
+        conn_remote = self.conn_for_acct(migration['aws_account'])
+
+        conn_es.put_container('metadata_test', headers=init_local_headers)
+        # Note: container last_modified dates are whole seconds, so sleep
+        # is needed to ensure remote is newer
+        time.sleep(2)
+        conn_remote.put_container('metadata_test',
+                                  headers=init_remote_headers)
+
+        # validate the acl exists on remote (sanity check)
+        scheme, rest = self.SWIFT_CREDS['authurl'].split(':', 1)
+        swift_host, _ = urllib.splithost(rest)
+
+        remote_swift = swiftclient.client.Connection(
+            authurl=self.SWIFT_CREDS['authurl'],
+            user=self.SWIFT_CREDS['dst']['user'],
+            key=self.SWIFT_CREDS['dst']['key'],
+            os_options={'object_storage_url': '%s://%s/v1/%s' % (
+                scheme, swift_host, migration['aws_account'].split(':')[0])})
+        etag = remote_swift.put_object('metadata_test', 'test', 'test')
+        self.assertEqual(hashlib.md5('test').hexdigest(), etag)
+
+        def key_val_copied(k, v):
+            test_hdrs = conn_es.head_container('metadata_test')
+            if k not in test_hdrs:
+                return False
+            if test_hdrs[k] == v:
+                return True
+            return False
+
+        key1_copied = partial(key_val_copied, key1, val1)
+        val3_copied = partial(key_val_copied, key3, val3)
+
+        def key_gone(key):
+            test_hdrs = conn_es.head_container('metadata_test')
+            if key not in test_hdrs:
+                return True
+            return False
+
+        # sanity check
+        self.assertTrue(key_val_copied(key2, val2))
+        self.assertTrue(key_gone(key1))
+
+        with self.migrator_running():
+            # verify really copied
+            wait_for_condition(5, key1_copied)
+            self.assertTrue(key_gone(key2))
+            self.assertTrue(val3_copied)
+
+    def test_container_metadata_copied_only_when_newer(self):
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_container_metadata_copied_only_when_newer()
+
+    def test_object_metadata_copied_only_when_newer(self):
+        migration = self.swift_migration()
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_object_metadata_copied_only_when_newer()
+
+    def test_propagate_object_meta(self):
+        # Not applicable here.
+        pass
+
+    def test_swift_versions_location(self):
+        # We don't do anything special on encoutering a versioned object.
+        pass
+
+    def test_swift_history_location(self):
+        # Not applicable.
+        pass
+
+    def test_put_on_unmigrated_container(self):
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': []}
+        return super(TestMetadataMigrator, self).\
+            test_put_on_unmigrated_container()
+
+    def test_deleted_source_objects(self):
+        migration = self.swift_migration()
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': []}
+        return super(TestMetadataMigrator, self).\
+            test_deleted_source_objects()
+
+    def test_post_deleted_source_objects(self):
+        migration = self.swift_migration()
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': []}
+        return super(TestMetadataMigrator, self).\
+            test_post_deleted_source_objects()
+
+    def _setup_deleted_container_test(self):
+        '''Common code for the deleted origin container tests'''
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+
+        conn_source = self.conn_for_acct(migration['aws_account'])
+        conn_destination = self.conn_for_acct_es(migration['account'])
+
+        conn_source.put_container('test-delete')
+        conn_source.put_object('test-delete', 'source_object', 'body')
+
+        def _check_object_copied():
+            try:
+                dog = conn_destination.get_container('test-delete')
+                hdrs, listing = dog
+                if not listing:
+                    return False
+                if listing[0]['name'] != 'source_object':
+                    return False
+                if 'swift' not in listing[0]['content_location']:
+                    return False
+                return True
+            except swiftclient.exceptions.ClientException as e:
+                if e.http_status == 404:
+                    return False
+
+        with self.migrator_running():
+            wait_for_condition(5, _check_object_copied)
+
+    def test_deleted_source_container(self):
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_deleted_source_container()
+
+    def test_deleted_container_after_new_object(self):
+        '''Destination container removed even if it has extra objects'''
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+
+        conn_source = self.conn_for_acct(migration['aws_account'])
+        conn_destination = self.conn_for_acct_es(migration['account'])
+
+        self._setup_deleted_container_test()
+        conn_destination.put_object('test-delete', 'new-object', 'new')
+        conn_source.delete_object('test-delete', 'source_object')
+        conn_source.delete_container('test-delete')
+
+        def _check_deleted_migrated_objects():
+            try:
+                conn_destination.head_container('test-delete')
+            except swiftclient.exceptions.ClientException as e:
+                if e.http_status == 404:
+                    return True
+
+        with self.assertRaises(swiftclient.exceptions.ClientException) as cm:
+            conn_source.head_container('test-delete')
+        self.assertEqual(404, cm.exception.http_status)
+
+        with self.migrator_running():
+            wait_for_condition(5, _check_deleted_migrated_objects)
+
+    def test_deleted_container_after_post(self):
+        '''Destination container removed even if it has been modified'''
+        migration = self._find_migration(
+            lambda cont: cont['aws_bucket'] == '/*')
+
+        conn_source = self.conn_for_acct(migration['aws_account'])
+        conn_destination = self.conn_for_acct_es(migration['account'])
+
+        self._setup_deleted_container_test()
+        conn_destination.post_container(
+            'test-delete',
+            {'x-container-meta-new-meta': 'value'})
+        conn_source.delete_object('test-delete', 'source_object')
+        conn_source.delete_container('test-delete')
+
+        def _check_deleted_migrated_objects():
+            try:
+                conn_destination.head_container('test-delete')
+            except swiftclient.exceptions.ClientException as e:
+                if e.http_status == 404:
+                    return True
+
+        with self.assertRaises(swiftclient.exceptions.ClientException) as cm:
+            conn_source.head_container('test-delete')
+        self.assertEqual(404, cm.exception.http_status)
+
+        with self.migrator_running():
+            wait_for_condition(5, _check_deleted_migrated_objects)
+
+    def test_deleted_object_pagination(self):
+        migration = self.swift_migration()
+        TestMetadataMigrator._es_shims = {
+            'conn_for_acct': [migration['account']],
+            'conn_for_acct_noshunt': [migration['account']]}
+        return super(TestMetadataMigrator, self).\
+            test_deleted_object_pagination()
+
+    def test_migrate_many_slos(self):
+        # The metadata migrator doesn't do anything special
+        # with large objects; it just adds the metadata from the manifest.
+        pass
+
+    def test_migrate_many_dlos(self):
+        # The metadata migrator doesn't do anything special
+        # with dlos either.
+        pass

--- a/test/unit/test_metadata_migrator.py
+++ b/test/unit/test_metadata_migrator.py
@@ -1,0 +1,2011 @@
+"""
+Copyright 2017 SwiftStack
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from contextlib import contextmanager
+import datetime
+import hashlib
+import json
+import logging
+import math
+import mock
+from s3_sync.base_sync import ProviderResponse
+import s3_sync.migrator
+import s3_sync.metadata_migrator
+from StringIO import StringIO
+from swift.common.internal_client import UnexpectedResponse
+from swift.common.utils import Timestamp
+import time
+import unittest
+from tempfile import mkdtemp
+import shutil
+import os
+import test_migrator
+from test_migrator import create_timestamp, create_list_timestamp
+import elasticsearch
+from s3_sync.utils import SWIFT_TIME_FMT
+
+
+class TestMetadataMigrator(test_migrator.TestMigrator):
+    def setUp(self):
+        config = {'aws_bucket': 'bucket',
+                  'account': 'AUTH_test',
+                  'aws_identity': 'source-account'}
+
+        self.swift_client = mock.Mock()
+
+        def _iter_yield_none(iterable):
+            for x in iterable:
+                yield x
+            while True:
+                yield None
+        self._iter_yield_none = _iter_yield_none
+
+        self.swift_client.es_iter_items.return_value =\
+            self._iter_yield_none([])
+
+        class FakeESResponse:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+        class FakeESRequest:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+            def get_response(self):
+                return FakeESResponse(self.status_int)
+        self.swift_client.create_container.return_value = FakeESRequest(200)
+
+        pool = mock.Mock()
+        pool.item.return_value.__enter__ = lambda *args: self.swift_client
+        pool.item.return_value.__exit__ = lambda *args: None
+        pool.max_size = 11
+        self.logger = logging.getLogger()
+        self.stream = StringIO()
+        self.logger.addHandler(logging.StreamHandler(self.stream))
+        self.migrator = s3_sync.metadata_migrator.MetadataMigrator(
+            config, None, 1000, 5, pool, self.logger, 0, 1)
+        self.migrator.status = mock.Mock()
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_all_buckets_next_pass_fails(self, create_provider_mock):
+        self.migrator.config['aws_bucket'] = '/*'
+        self.migrator._process_container = mock.Mock(
+            side_effect=Exception('kaboom'))
+        create_provider_mock.return_value.list_buckets.side_effect = \
+            [ProviderResponse(True, 200, [], [
+                {'name': 'bucket',
+                 'content_location': 'some_provider'}]),
+             ProviderResponse(True, 200, [], [])]
+        self.migrator.next_pass()
+        self.assertEqual('Failed to migrate "bucket"',
+                         self.stream.getvalue().splitlines()[0])
+
+    @mock.patch('s3_sync.metadata_migrator.time')
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_create_container_timeout(self, create_provider_mock, time_mock):
+        provider = create_provider_mock.return_value
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'test'}])
+
+        resp = mock.Mock()
+        resp.status = 200
+        resp.headers = {}
+        provider.head_bucket.return_value = resp
+        self.swift_client.es_iter_objects.return_value = iter([])
+        self.swift_client.container_exists.return_value = False
+
+        def fake_app(env, func):
+                return func(200, [])
+
+        self.swift_client.app.side_effect = fake_app
+
+        time_mock.time.side_effect = (0, 0, 1)
+        self.migrator.status.get_migration.return_value = {}
+
+        self.migrator.next_pass()
+        self.assertEqual(
+            'MigrationError: Timeout while creating container "bucket"',
+            self.get_log_lines()[-1])
+        self.swift_client.create_container.assert_called_once_with(
+            self.migrator.config, self.migrator.config['account'],
+            self.migrator.config['container'],
+            {'x-container-sysmeta-multi-cloud-internal-migrator': 'migrating'})
+
+        self.swift_client.container_exists.assert_has_calls(
+            [mock.call(self.migrator.config,
+                       self.migrator.config['account'],
+                       self.migrator.config['container'])] * 2)
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_etag_mismatch(self, create_provider_mock):
+        self.migrator.config['protocol'] = 'swift'
+        provider = create_provider_mock.return_value
+        self.migrator.status.get_migration.return_value = {}
+
+        objects = {
+            'dlo': {
+                'list_entry': {
+                    'last-modified': create_list_timestamp(1.5e9),
+                    'hash': 'deadbeef'},
+                'headers': {
+                    'x-object-manifest': 'segments/',
+                    'last-modified': create_timestamp(1.5e9)
+                }
+            },
+            'slo': {
+                'list_entry': {
+                    'last-modified': create_list_timestamp(1.4e9),
+                    'hash': 'feedbead'},
+                'headers': {
+                    'x-static-large-object': True,
+                    'last-modified': create_timestamp(1.4e9)
+                }
+            }
+        }
+
+        swift_objects = {
+            'dlo': {
+                'name': 'dlo',
+                'last_nodified': create_list_timestamp(1.5e9),
+                'etag': 'other'
+            },
+            'slo': {
+                'name': 'slo',
+                'last_nodified': create_list_timestamp(1.4e9),
+                'etag': 'other-still'
+            }
+        }
+
+        def _head_object(key, **kwargs):
+            resp = mock.Mock()
+            resp.headers = objects[key]['headers']
+            resp.headers['etag'] = objects[key]['list_entry']['hash']
+            resp.status = 200
+            resp.body = 'nothing'
+            return resp
+
+        def _get_object_metadata(config, _account, _container, key):
+            return swift_objects[key]
+
+        self.swift_client.container_exists.return_value = True
+        self.swift_client.get_object_metadata.return_value =\
+            _get_object_metadata
+        self.migrator._read_account_headers = mock.Mock(return_value={})
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {},
+            [dict([('name', k)] + objects[k]['list_entry'].items())
+             for k in sorted(objects.keys())])
+        provider.head_object.side_effect = _head_object
+        provider.head_bucket.return_value = mock.Mock(status=200, headers={})
+        provider.get_manifest.return_value = {}
+        provider.head_account.return_value = {}
+
+        self.migrator.next_pass()
+        # The metadata migrator ignores large object content completely,
+        # so will migrate the objects - unlike the vanilla migrator
+        self.assertEqual("Copied \"bucket/dlo\"\nCopied \"bucket/slo\"\n",
+                         self.stream.getvalue())
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_migrate_all_containers_next_pass(self, create_provider_mock):
+        provider_mock = mock.Mock()
+        buckets = [{'name': 'bucket1', 'content_location': 'other'},
+                   {'name': 'bucket2', 'content_location': 'other'}]
+        provider_mock.list_buckets.side_effect = [
+            ProviderResponse(True, 200, [], buckets),
+            ProviderResponse(True, 200, [], [])]
+        provider_mock.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'obj'}])
+        provider_mock.head_object.return_value = ProviderResponse(
+            True, 200, {'last-modified': create_timestamp(1.5e9),
+                        'etag': 'deadbeef',
+                        'Content-Length': '1337'},
+            StringIO(''))
+
+        self.swift_client.es_iter_items.return_value =\
+            self._iter_yield_none([None])
+        create_provider_mock.return_value = provider_mock
+        self.migrator.config = {
+            'account': 'AUTH_dev',
+            'aws_bucket': '/*',
+        }
+        temp_dir = mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(temp_dir))
+        status_file = os.path.join(temp_dir, 'migrator.status')
+        self.migrator.status = s3_sync.migrator.Status(status_file)
+        with mock.patch('time.time', return_value=100.0):
+            handled_containers = self.migrator.next_pass()
+
+        self.assertEqual(
+            [{'aws_bucket': 'bucket1',
+              'account': 'AUTH_dev',
+              'container': 'bucket1',
+              'all_buckets': True},
+             {'aws_bucket': 'bucket2',
+              'account': 'AUTH_dev',
+              'container': 'bucket2',
+              'all_buckets': True}],
+            handled_containers)
+
+        self.assertEqual(['Copied "bucket1/obj"',
+                          'Copied "bucket2/obj"'],
+                         self.stream.getvalue().splitlines())
+        with open(status_file) as f:
+            status = json.load(f)
+        self.assertEqual(status, [{
+            'status': {
+                'marker': 'obj',
+                'moved_count': 1,
+                'finished': 100.0,
+                'scanned_count': 1,
+                'bytes_count': 0,
+            },
+            'account': 'AUTH_dev',
+            'container': 'bucket1',
+            'all_buckets': True,
+            'aws_bucket': 'bucket1',
+        }, {
+            'status': {
+                'marker': 'obj',
+                'moved_count': 1,
+                'finished': 100.0,
+                'scanned_count': 1,
+                'bytes_count': 0,
+            },
+            'account': 'AUTH_dev',
+            'container': 'bucket2',
+            'all_buckets': True,
+            'aws_bucket': 'bucket2',
+        }])
+        self.migrator.config = {
+            'account': 'AUTH_dev',
+            'aws_bucket': 'bucket3',
+            'container': 'bucket3',
+        }
+        with mock.patch('time.time', return_value=100.0):
+            self.migrator.next_pass()
+        with open(status_file) as f:
+            status = json.load(f)
+        self.assertEqual(status, [{
+            'status': {
+                'marker': 'obj',
+                'moved_count': 1,
+                'finished': 100.0,
+                'scanned_count': 1,
+                'bytes_count': 0,
+            },
+            'account': 'AUTH_dev',
+            'container': 'bucket1',
+            'all_buckets': True,
+            'aws_bucket': 'bucket1',
+        }, {
+            'status': {
+                'marker': 'obj',
+                'moved_count': 1,
+                'finished': 100.0,
+                'scanned_count': 1,
+                'bytes_count': 0,
+            },
+            'account': 'AUTH_dev',
+            'container': 'bucket2',
+            'all_buckets': True,
+            'aws_bucket': 'bucket2',
+        }, {
+            'status': {
+                'marker': 'obj',
+                'moved_count': 1,
+                'finished': 100.0,
+                'scanned_count': 1,
+                'bytes_count': 0,
+            },
+            'account': 'AUTH_dev',
+            'container': 'bucket3',
+            'aws_bucket': 'bucket3',
+        }])
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_migrate_dlo(self, create_provider_mock):
+        self.migrator.config['protocol'] = 'swift'
+        provider = create_provider_mock.return_value
+        self.migrator.status.get_migration.return_value = {}
+        segments_container = 'dlo-segments'
+
+        objects = {
+            'dlo': {
+                'remote_headers': {
+                    'x-object-meta-custom': 'dlo-meta',
+                    'last-modified': create_timestamp(1.5e9),
+                    'x-object-manifest': '%s/' % segments_container,
+                    'etag': 'd10',
+                    'Content-Length': '10'},
+                'expected_headers': {
+                    'x-object-meta-custom': 'dlo-meta',
+                    'x-timestamp': Timestamp(1.5e9).internal,
+                    'x-object-manifest': '%s/' % segments_container,
+                    'etag': 'd10',
+                    'Content-Length': '10',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.5e9).internal)}
+            },
+            '1': {
+                'remote_headers': {
+                    'x-object-meta-part': 'part-1',
+                    'last-modified': create_timestamp(1.4e9),
+                    'etag': '3e41',
+                    'Content-Length': '1'},
+                'expected_headers': {
+                    'x-object-meta-part': 'part-1',
+                    'etag': '3e41',
+                    'x-timestamp': Timestamp(1.4e9).internal,
+                    'Content-Length': '1',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.4e9).internal)}
+            },
+            '2': {
+                'remote_headers': {
+                    'x-object-meta-part': 'part-2',
+                    'last-modified': create_timestamp(1.1e9),
+                    'etag': '3e42',
+                    'Content-Length': '2'},
+                'expected_headers': {
+                    'x-object-meta-part': 'part-2',
+                    'etag': '3e42',
+                    'x-timestamp': Timestamp(1.1e9).internal,
+                    'Content-Length': '2',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.1e9).internal)}
+            },
+            '3': {
+                'remote_headers': {
+                    'x-object-meta-part': 'part-3',
+                    'last-modified': create_timestamp(1.2e9),
+                    'etag': '3e43',
+                    'Content-Length': '3'},
+                'expected_headers': {
+                    'x-object-meta-part': 'part-3',
+                    'etag': '3e43',
+                    'x-timestamp': Timestamp(1.2e9).internal,
+                    'Content-Length': '3',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.2e9).internal)}
+            }
+        }
+
+        containers = {segments_container: False,
+                      self.migrator.config['container']: False}
+
+        swift_404_resp = mock.Mock()
+        swift_404_resp.status_int = 404
+
+        class FakeESResponse:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+        class FakeESRequest:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+            def get_response(self):
+                return FakeESResponse(self.status_int)
+
+        def create_container(config, account, container, headers={}):
+            containers[container] = True
+            return FakeESRequest(200)
+
+        def container_exists(config, account, container):
+            return containers[container]
+
+        def fake_app(env, func):
+            containers[env['PATH_INFO'].split('/')[3]] = True
+            return func(200, [])
+
+        def get_container_metadata(config, account, container):
+            if not containers[container]:
+                raise UnexpectedResponse('', swift_404_resp)
+
+        def _make_path(account, container):
+            return '/'.join(['http://test/v1', account, container])
+
+        def head_object(name, **args):
+            if name not in objects.keys():
+                raise RuntimeError('Unknown object: %s' % name)
+            if name == 'dlo':
+                return ProviderResponse(
+                    True, 200, objects[name]['remote_headers'], StringIO(''))
+            return ProviderResponse(
+                True, 200, objects[name]['remote_headers'],
+                StringIO('object body'))
+
+        def upload_object(config, body, account, container, key, headers):
+            if not containers[container]:
+                raise UnexpectedResponse('', swift_404_resp)
+
+        def list_objects(marker, chunk, prefix, bucket=None):
+            if bucket is None or bucket == self.migrator.config['container']:
+                return ProviderResponse(True, 200, {}, [{'name': 'dlo'}])
+            elif bucket == segments_container:
+                if marker == '':
+                    return ProviderResponse(
+                        True, 200, {},
+                        [{'name': '1'}, {'name': '2'}, {'name': '3'}])
+                if marker == '3':
+                    return ProviderResponse(True, 200, {}, [])
+            raise RuntimeError('Unknown container')
+
+        self.swift_client.container_exists.side_effect = container_exists
+        self.swift_client.get_container_metadata.side_effect = \
+            get_container_metadata
+        self.swift_client.app.side_effect = fake_app
+        self.swift_client.make_path.side_effect = _make_path
+        self.swift_client.upload_object.side_effect = upload_object
+        self.swift_client.create_container.side_effect = create_container
+        self.migrator._read_account_headers = mock.Mock(return_value={})
+
+        bucket_resp = mock.Mock()
+        bucket_resp.status = 200
+        bucket_resp.headers = {}
+
+        provider.head_account.return_value = {}
+        provider.head_bucket.return_value = bucket_resp
+        provider.list_objects.side_effect = list_objects
+        provider.head_object.side_effect = head_object
+        self.swift_client.es_iter_objects.return_value = iter([])
+
+        self.migrator.next_pass()
+
+        self.swift_client.upload_object.assert_has_calls(
+            [mock.call(self.migrator.config, mock.ANY,
+                       self.migrator.config['account'],
+                       'bucket', 'dlo',
+                       objects['dlo']['expected_headers'])])
+
+        class NotAnAssertionError(Exception):
+            pass
+
+        try:
+            self.swift_client.upload_object.assert_has_calls(
+                [mock.call(self.migrator.config, mock.ANY,
+                           self.migrator.config['account'],
+                           'dlo-segments', '2',
+                           objects['2']['expected_headers']),
+                 mock.call(self.migrator.config, mock.ANY,
+                           self.migrator.config['account'],
+                           'dlo-segments', '3',
+                           objects['3']['expected_headers']),
+                 mock.call(self.migrator.config, mock.ANY,
+                           self.migrator.config['account'],
+                           self.migrator.config['container'], 'dlo',
+                           objects['dlo']['expected_headers'])])
+            raise NotAnAssertionError()
+        except AssertionError:
+            pass
+        except NotAnAssertionError:
+            raise AssertionError(
+                "Metadata migrator should not migrate DLO segments")
+
+        parts = {'dlo': False}
+        for call in self.swift_client.upload_object.mock_calls:
+            config, body, acct, cont, obj, headers = call[1]
+            if parts[obj]:
+                continue
+            self.assertEqual(self.migrator.config['container'], cont)
+            parts[obj] = True
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_migrate_objects(self, create_provider_mock):
+        provider = create_provider_mock.return_value
+        self.migrator.status.get_migration.return_value = {}
+
+        utcnow = datetime.datetime.utcnow()
+        now = (utcnow - s3_sync.migrator.EPOCH).total_seconds()
+
+        tests = [{
+            'objects': {
+                'foo': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.5e9),
+                        'x-timestamp': 1499999999.66,
+                        'etag': 'f001a4',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1499999999.66).internal,
+                        'etag': 'f001a4',
+                        'last-modified': mock.ANY,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1499999999.66).internal),
+                        'Content-Length': '1024'},
+                    'list-time': create_list_timestamp(1.5e9),
+                    'hash': 'etag'
+                },
+                'bar': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.4e9),
+                        'etag': 'ba3',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        'etag': 'ba3',
+                        'last-modified': mock.ANY,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal),
+                        'Content-Length': '1024'},
+                    'list-time': create_list_timestamp(1.4e9),
+                    'hash': 'etag'
+                }
+            },
+        }, {
+            'objects': {
+                'foo': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.5e9),
+                        'etag': 'f001a4',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        'etag': 'f001a4',
+                        'last-modified': mock.ANY,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal),
+                        'Content-Length': '1024'},
+                    'list-time': create_list_timestamp(1.5e9),
+                    'hash': 'etag'
+                },
+                'bar': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.4e9),
+                        'etag': 'ba3',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        'etag': 'ba3',
+                        'last-modified': mock.ANY,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal),
+                        'Content-Length': '1024'},
+                    'list-time': create_list_timestamp(1.4e9),
+                    'hash': 'etag'
+                }
+            },
+            'config': {
+                'aws_bucket': 'container',
+                'protocol': 'swift'
+            }
+        }, {
+            'objects': {
+                'foo': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.5e9),
+                        'etag': 'f001a4',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        'etag': 'f001a4',
+                        'last-modified': mock.ANY,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal),
+                        'Content-Length': '1024'},
+                    'list-time': create_list_timestamp(1.5e9),
+                    'hash': 'etag'
+                },
+                'bar': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.4e9),
+                        'etag': 'ba3',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        'etag': 'ba3',
+                        'last-modified': mock.ANY,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
+                    'list-time': create_list_timestamp(1.4e9),
+                    'hash': 'etag'
+                }
+            },
+            'config': {
+                'aws_bucket': 'container',
+                'protocol': 'swift'
+            },
+            'local_objects': [
+                {'name': 'foo',
+                 'last_modified': create_list_timestamp(1.5e9),
+                 'hash': 'etag'},
+                {'name': 'bar',
+                 'last_modified': create_list_timestamp(1.4e9),
+                 'hash': 'etag'}
+            ],
+            'migrated': []
+        }, {
+            'objects': {
+                'foo': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.5e9),
+                        'etag': 'f001a4',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        'etag': 'f001a4',
+                        'last-modified': mock.ANY,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
+                    'list-time': create_list_timestamp(1.5e9),
+                    'hash': 'etag'
+                },
+                'bar': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.4e9),
+                        'etag': 'ba3',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        'etag': 'ba3',
+                        'last-modified': mock.ANY,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
+                    'list-time': create_list_timestamp(1.4e9),
+                    'hash': 'etag'
+                }
+            },
+            'config': {
+                'aws_bucket': 'container',
+                'protocol': 'swift'
+            },
+            'local_objects': [
+                {'name': 'foo',
+                 'last_modified': create_list_timestamp(1.4e9),
+                 'hash': 'old-etag'},
+                {'name': 'bar',
+                 'last_modified': create_list_timestamp(1.3e9),
+                 'hash': 'old-etag'}
+            ],
+            'migrated': ['foo', 'bar']
+        }, {
+            'objects': {
+                'foo': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(1.5e9),
+                        'etag': 'f001a4',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        'etag': 'f001a4',
+                        'last-modified': mock.ANY,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
+                    'list-time': create_list_timestamp(1.5e9),
+                    'hash': 'etag'
+                },
+                'bar': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(now - 35.0),
+                        'etag': 'ba3',
+                        'Content-Length': '1024'},
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'etag': 'ba3',
+                        'last-modified': mock.ANY,
+                        'x-timestamp':
+                            Timestamp(math.floor(now - 35.0)).internal,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(math.floor(now - 35.0)).internal)},
+                    'list-time': create_list_timestamp(now - 35.0),
+                    'hash': 'etag'
+                },
+                'baz': {
+                    'remote_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'last-modified': create_timestamp(now),
+                        'etag': 'ba33',
+                        'Content-Length': '1024',
+                    },
+                    'expected_headers': {
+                        'x-object-meta-custom': 'custom',
+                        'etag': 'ba33',
+                        'last-modified': mock.ANY,
+                        'x-timestamp': Timestamp(math.floor(now)).internal,
+                        'Content-Length': '1024',
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(math.floor(now)).internal)},
+                    'list-time': create_list_timestamp(math.floor(now)),
+                    'hash': 'etag'
+                }
+            },
+            'config': {
+                'aws_bucket': 'container',
+                'protocol': 'swift',
+                'older_than': 30,
+            },
+            'local_objects': [
+                {'name': 'foo',
+                 'last_modified': create_list_timestamp(1.4e9),
+                 'hash': 'old-etag'},
+                {'name': 'bar',
+                 'last_modified': create_list_timestamp(1.3e9),
+                 'hash': 'old-etag'}
+            ],
+            'migrated': ['foo', 'bar']
+        }]
+        config = self.migrator.config
+        self.migrator._read_account_headers = mock.Mock(return_value={})
+
+        for test in tests:
+            objects = test['objects']
+            if 'migrated' not in test:
+                migrated = objects.keys()
+            else:
+                migrated = test['migrated']
+            test_config = dict(config)
+            for k, v in test.get('config', {}).items():
+                test_config[k] = v
+                if k == 'aws_bucket':
+                    test_config['container'] = v
+            self.migrator.config = test_config
+
+            provider.reset_mock()
+            self.swift_client.reset_mock()
+            self.swift_client.container_exists.return_value = True
+            provider.head_account.return_value = {}
+
+            local_objects = test.get('local_objects', [])
+
+            def head_object(name, **args):
+                if name not in objects.keys():
+                    raise RuntimeError('Unknown object: %s' % name)
+                if name not in migrated:
+                    raise RuntimeError('Object should not be moved %s' % name)
+                return ProviderResponse(
+                    True, 200, objects[name]['remote_headers'],
+                    StringIO('object body'))
+
+            provider.list_objects.return_value = ProviderResponse(
+                True, 200, {},
+                [{'name': name,
+                  'last_modified': objects[name]['list-time'],
+                  'hash': objects[name]['hash']}
+                 for name in objects.keys()])
+            provider.head_bucket.return_value = mock.Mock(
+                status=200, headers={})
+            provider.head_object.side_effect = head_object
+            self.swift_client.es_iter_objects.return_value =\
+                self._iter_yield_none(local_objects)
+
+            self.migrator.next_pass()
+
+            self.swift_client.upload_object.assert_has_calls(
+                [mock.call(self.migrator.config, mock.ANY,
+                           self.migrator.config['account'],
+                           self.migrator.config['aws_bucket'], name,
+                           objects[name]['expected_headers'])
+                 for name in migrated])
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_migrate_slo(self, create_provider_mock):
+        self.migrator.config['protocol'] = 'swift'
+        provider = create_provider_mock.return_value
+        self.migrator.status.get_migration.return_value = {}
+        segments_container = '/slo-segments'
+
+        manifest = [{'name': '/'.join([segments_container, 'part1'])},
+                    {'name': '/'.join([segments_container, 'part2'])}]
+        manifest_etag = hashlib.md5(json.dumps(manifest)).hexdigest()
+        objects = {
+            'slo': {
+                'remote_headers': {
+                    'x-object-meta-custom': 'slo-meta',
+                    'last-modified': create_timestamp(1.5e9),
+                    'x-static-large-object': 'True',
+                    'Content-Length': str(len(json.dumps(manifest))),
+                    'etag': manifest_etag},
+                'expected_headers': {
+                    'x-object-meta-custom': 'slo-meta',
+                    'x-timestamp': Timestamp(1.5e9).internal,
+                    'x-static-large-object': 'True',
+                    'Content-Length': str(len(json.dumps(manifest))),
+                    'etag': manifest_etag,
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.5e9).internal)}
+            },
+            'part1': {
+                'remote_headers': {
+                    'x-object-meta-part': 'part-1',
+                    'last-modified': create_timestamp(1.4e9),
+                    'etag': 'part1',
+                    'Content-Length': '1024'},
+                'expected_headers': {
+                    'x-object-meta-part': 'part-1',
+                    'x-timestamp': Timestamp(1.4e9).internal,
+                    'etag': 'part1',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.4e9).internal),
+                    'Content-Length': '1024'}
+            },
+            'part2': {
+                'remote_headers': {
+                    'x-object-meta-part': 'part-2',
+                    'last-modified': create_timestamp(1.1e9),
+                    'etag': 'part2',
+                    'Content-Length': '1024'},
+                'expected_headers': {
+                    'x-object-meta-part': 'part-2',
+                    'x-timestamp': Timestamp(1.1e9).internal,
+                    'etag': 'part2',
+                    'last-modified': mock.ANY,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.1e9).internal),
+                    'Content-Length': '1024'}
+            }
+        }
+
+        containers = {segments_container[1:]: False,
+                      self.migrator.config['container']: False}
+
+        swift_404_resp = mock.Mock()
+        swift_404_resp.status_int = 404
+
+        class FakeESResponse:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+        class FakeESRequest:
+            def __init__(self, status_int):
+                self.status_int = status_int
+
+            def get_response(self):
+                return FakeESResponse(self.status_int)
+
+        def create_container(config, account, container, headers={}):
+            containers[container] = True
+            return FakeESRequest(200)
+
+        def container_exists(config, account, container):
+            return containers[container]
+
+        def get_container_metadata(config, account, container):
+            if not containers[container]:
+                raise UnexpectedResponse('', swift_404_resp)
+
+        def head_object(name, bucket=None):
+            if bucket != 'bucket':
+                raise RuntimeError('wrong container: %s' % bucket)
+            if name is not 'slo':
+                raise RuntimeError(
+                    'attempt to migrate segment object: %s' % name)
+            resp = mock.Mock()
+            resp.status = 200
+            resp.headers = objects[name]['remote_headers']
+            return resp
+
+        def upload_object(config, body, account, container, key, headers):
+            if not containers[container]:
+                raise UnexpectedResponse('', swift_404_resp)
+
+        self.swift_client.create_container.side_effect = create_container
+        self.swift_client.container_exists.side_effect = container_exists
+        self.swift_client.get_container_metadata.side_effect = \
+            get_container_metadata
+        self.swift_client.get_object_metadata.side_effect = UnexpectedResponse(
+            '', swift_404_resp)
+        self.swift_client.upload_object.side_effect = upload_object
+        self.migrator._read_account_headers = mock.Mock(return_value={})
+
+        bucket_resp = mock.Mock()
+        bucket_resp.status = 200
+        bucket_resp.headers = {}
+
+        provider.head_account.return_value = {}
+        provider.head_bucket.return_value = bucket_resp
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'slo'}])
+        provider.head_object.side_effect = head_object
+        self.swift_client.es_iter_objects.return_value =\
+            self._iter_yield_none([])
+
+        self.migrator.next_pass()
+
+        self.swift_client.upload_object.assert_has_calls(
+            [mock.call(mock.ANY, mock.ANY, self.migrator.config['account'],
+                       self.migrator.config['container'],
+                       'slo',
+                       objects['slo']['expected_headers'])])
+
+        class NotAnAssertionError(Exception):
+            pass
+
+        try:
+            self.swift_client.upload_object.assert_has_calls(
+                [mock.call(mock.ANY, mock.ANY, self.migrator.config['account'],
+                           'slo-segments',
+                           'part1',
+                           objects['part1']['expected_headers']),
+                 mock.call(mock.ANY, mock.ANY, self.migrator.config['account'],
+                           'slo-segments',
+                           'part2',
+                           objects['part2']['expected_headers'])])
+            raise NotAnAssertionError()
+        except AssertionError:
+            pass
+        except NotAnAssertionError:
+            raise AssertionError(
+                "Metadata migrator should not migrate SLO segments")
+
+        parts = {'slo': False}
+        for call in self.swift_client.upload_object.mock_calls:
+            config, body, acct, cont, obj, headers = call[1]
+            if parts[obj]:
+                continue
+            self.assertEqual(self.migrator.config['container'], cont)
+            parts[obj] = True
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_missing_container(self, create_provider_mock):
+        tests = [
+            ({'protocol': 'swift'}, {'x-container-meta-foo': 'foo'}),
+            ({}, {}),
+            ({'protocol': 'swift'}, {'x-container-read': '.r*',
+                                     'x-container-write': 'AUTH_bob'})
+        ]
+        provider = create_provider_mock.return_value
+        config = self.migrator.config
+        self.migrator._read_account_headers = mock.Mock(return_value={})
+
+        for test_config, container_headers in tests:
+            self.migrator.config = dict(config, **test_config)
+
+            provider.reset_mock()
+            self.swift_client.reset_mock()
+            provider.head_account.return_value = {}
+            provider.list_objects.return_value = ProviderResponse(
+                True, 200, {}, [{'name': 'test'}])
+            provider.get_object.return_value = ProviderResponse(
+                True, 200, {'last-modified': create_timestamp(1.5e9)},
+                StringIO(''))
+
+            if self.migrator.config.get('protocol') == 'swift':
+                resp = mock.Mock()
+                resp.status = 200
+                resp.headers = container_headers
+                provider.head_bucket.return_value = resp
+                swift_404_resp = mock.Mock()
+                swift_404_resp.status_int = 404
+
+                def fake_get_metadata(config, account, container):
+                    raise UnexpectedResponse('', swift_404_resp)
+
+                self.swift_client.get_container_metadata.side_effect = \
+                    fake_get_metadata
+                self.swift_client.container_exists.side_effect = (True,)
+            else:
+                self.swift_client.container_exists.side_effect = (False, True)
+
+            self.swift_client.es_iter_objects.return_value = iter([])
+            self.migrator.status.get_migration.return_value = {}
+
+            self.migrator.next_pass()
+            if test_config.get('protocol') == 'swift':
+                provider.list_objects.assert_called_once_with(
+                    '', self.migrator.work_chunk, '', bucket='bucket')
+                provider.head_bucket.assert_has_calls(
+                    [mock.call(self.migrator.config['container'])] * 2)
+            else:
+                provider.list_objects.assert_called_once_with(
+                    '', self.migrator.work_chunk, '', bucket='bucket')
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_paginate_migration_listings(self, create_provider_mock):
+        self.migrator.status.get_migration.return_value = {
+            'marker': 'bar'}
+        provider = create_provider_mock.return_value
+        provider.list_objects.return_value = mock.Mock(status=200, body=[])
+        self.swift_client.es_iter_items.return_value =\
+            self._iter_yield_none([])
+
+        self.migrator.next_pass()
+
+        self.swift_client.es_iter_items.assert_has_calls(
+            [mock.call(
+                self.migrator.config,
+                self.migrator.config['account'],
+                self.migrator.config['container'],
+                'bar',
+                mock.ANY),
+             mock.call(
+                self.migrator.config,
+                self.migrator.config['account'],
+                self.migrator.config['container'],
+                '',
+                mock.ANY)])
+        provider.list_objects.assert_has_calls(
+            [mock.call(
+                'bar', 1000, '', bucket=self.migrator.config['aws_bucket']),
+             mock.call(
+                '', 1000, '', bucket=self.migrator.config['aws_bucket'])])
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_reconcile_deleted_object(self, create_provider_mock):
+        provider_mock = create_provider_mock.return_value
+        provider_mock.list_objects.side_effect = [
+            ProviderResponse(True, 200, {}, [{'name': 'qux'}]),
+            ProviderResponse(True, 200, {}, [])]
+        provider_mock.get_object.return_value = ProviderResponse(
+            True, 200,
+            {'last-modified': create_timestamp(1.5e9),
+             'etag': 'deadbeef',
+             'Content-Length': str(2**10)},
+            [])
+
+        def _head_object(key, **kwargs):
+            resp = mock.Mock()
+            resp.headers = {
+                'etag': 'deadbeef',
+                'last-modified': create_timestamp(1.5e9)}
+            resp.status = 200
+            resp.body = 'nothing'
+            return resp
+        provider_mock.head_object = _head_object
+
+        swift_404_resp = mock.Mock()
+        swift_404_resp.status_int = 404
+        self.migrator.status.get_migration.return_value = {}
+
+        self.swift_client.es_iter_items.return_value = self._iter_yield_none(
+            [{"name": "foo"}, None])
+
+        self.swift_client.get_object_metadata.side_effect = UnexpectedResponse(
+            '', swift_404_resp)
+
+        self.migrator.next_pass()
+
+        internal_header = s3_sync.utils.get_sys_migrator_header('object')
+
+        self.swift_client.upload_object.assert_called_once_with(
+            self.migrator.config,
+            mock.ANY,
+            self.migrator.config['account'],
+            self.migrator.config['aws_bucket'],
+            'qux',
+            {internal_header: '1500000000.00000',
+             'x-timestamp': '1500000000.00000',
+             'etag': 'deadbeef',
+             'last-modified': mock.ANY})
+
+    def test_reconcile_deleted_timestamps(self):
+        internal_header = s3_sync.utils.get_sys_migrator_header('object')
+        tests = [
+            ({
+                'x-timestamp': '1500000000.00000',
+                'x-backend-timestamp': '1500000001.00000_0000000000000001',
+                'x-backend-durable-timestamp':
+                    '1500000002.00000_0000000000000001',
+                'last-modified': 'Fri, 14 Jul 2017 02:40:10 GMT',
+                internal_header: '1500000000.00000',
+            },
+                '1500000002.00000_0000000000000002'),
+            ({
+                'x-timestamp': '1500000000.00000',
+                'x-backend-timestamp': '1500000001.00000_0000000000000001',
+                'last-modified': 'Fri, 14 Jul 2017 02:40:10 GMT',
+                internal_header: '1500000000.00000',
+            },
+                '1500000001.00000_0000000000000002'),
+            ({
+                'x-timestamp': '1500000000.00000',
+                'last-modified': 'Fri, 14 Jul 2017 02:40:10 GMT',
+                internal_header: '1500000000.00000',
+            },
+                '1500000000.00000_0000000000000001'),
+            ({
+                'last-modified': 'Fri, 14 Jul 2017 02:40:10 GMT',
+                internal_header: '1500000000.00000',
+            },
+                '1500000010.00000_0000000000000001'),
+            ({
+                internal_header: '1500000000.00000',
+            },
+                None),
+        ]
+        self.swift_client.delete_object.return_value = \
+            ProviderResponse(True, 204, {}, [])
+
+        for obj_headers, want in tests:
+
+            self.swift_client.get_object_metadata.return_value = obj_headers
+            self.migrator._reconcile_deleted_objects('foo', 'bar')
+
+            hdrs = {}
+            if want:
+                hdrs = {'x-timestamp': want}
+            self.assertEqual(
+                self.swift_client.delete_object.call_args,
+                mock.call(self.migrator.config,
+                          self.migrator.config['account'],
+                          'foo',
+                          'bar',
+                          hdrs))
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_reconcile_deleted_container(self, create_provider_mock):
+        self.migrator.config['aws_bucket'] = '/*'
+        create_provider_mock.list_buckets.return_value = \
+            iter([ProviderResponse(True, 200, [], [])])
+
+        self.migrator.status.get_migration.return_value = {}
+
+        self.swift_client.es_iter_items.return_value = self._iter_yield_none(
+            [{"name": "bucket"}, None])
+        self.swift_client.get_container_metadata.return_value = {
+            s3_sync.utils.get_sys_migrator_header('container'):
+                s3_sync.utils.MigrationContainerStates.MIGRATING}
+
+        self.migrator.next_pass()
+        self.swift_client.delete_container.assert_called_once_with(
+            self.migrator.config,
+            self.migrator.config['account'],
+            "bucket")
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_reconcile_already_deleted_container(self, create_provider_mock):
+        self.migrator.config['aws_bucket'] = '/*'
+        create_provider_mock.list_buckets.return_value = \
+            iter([ProviderResponse(True, 200, [], [])])
+
+        self.migrator.status.get_migration.return_value = {}
+
+        self.swift_client.es_iter_items.return_value = self._iter_yield_none(
+            [{"name": "bucket"}, None])
+
+        swift_404_resp = mock.Mock()
+        swift_404_resp.status_int = 404
+
+        def _get_container_metadata(config, account, container):
+            raise UnexpectedResponse('', swift_404_resp)
+        self.swift_client.get_container_metadata.side_effect =\
+            _get_container_metadata
+
+        self.migrator.next_pass()
+        self.assertEqual('Container %s/%s already removed' % (
+            self.migrator.config['account'], "bucket"),
+            self.stream.getvalue().splitlines()[1])
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_reconcile_deleted_container_error(self, create_provider_mock):
+        self.migrator.config['aws_bucket'] = '/*'
+        create_provider_mock.list_buckets.return_value = \
+            iter([ProviderResponse(True, 200, [], [])])
+
+        self.migrator.status.get_migration.return_value = {}
+
+        self.swift_client.es_iter_items.return_value = self._iter_yield_none(
+            [{"name": "bucket"}, None])
+
+        swift_500_resp = mock.Mock()
+        swift_500_resp.status_int = 500
+
+        def _get_container_metadata(config, account, container):
+            raise UnexpectedResponse('', swift_500_resp)
+        self.swift_client.get_container_metadata.side_effect =\
+            _get_container_metadata
+
+        self.migrator.next_pass()
+        self.assertEqual('Failed to delete container "%s/%s"' % (
+            self.migrator.config['account'], "bucket"),
+            self.stream.getvalue().splitlines()[1])
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_reconcile_client_created_container(self, create_provider_mock):
+        self.migrator.config['aws_bucket'] = '/*'
+        create_provider_mock.list_buckets.return_value = \
+            iter([ProviderResponse(True, 200, [], [])])
+
+        self.migrator.status.get_migration.return_value = {}
+
+        self.swift_client.es_iter_items.return_value = self._iter_yield_none(
+            [{"name": "bucket"}, None])
+
+        self.swift_client.get_container_metadata.return_value = {}
+
+        self.migrator.next_pass()
+        self.assertEqual('Not removing container %s/%s: ' % (
+            self.migrator.config['account'], "bucket") +
+            'created by a client.',
+            self.stream.getvalue().splitlines()[1])
+
+
+class TestMetadataMigratorStatus(test_migrator.TestStatus):
+    pass
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.stream = StringIO()
+        self.logger.addHandler(logging.StreamHandler(self.stream))
+        self.conf = {
+            'metadata_migrations': [],
+            'migration_status': mock.Mock(),
+            'internal_pool': None,
+            'logger': self.logger,
+            'items_chunk': None,
+            'workers': 5,
+            'node_id': 0,
+            'nodes': 1,
+            'poll_interval': 30,
+            'once': True,
+        }
+
+    @contextmanager
+    def patch(self, name, **kwargs):
+        with mock.patch('s3_sync.metadata_migrator.' + name,
+                        **kwargs) as mocked:
+            yield mocked
+
+    def pop_log_lines(self):
+        lines = self.stream.getvalue()
+        self.stream.seek(0)
+        self.stream.truncate()
+        return lines
+
+    def test_run_once(self):
+        start = time.time()
+        with self.patch('time') as mocktime:
+            mocktime.time.side_effect = [start, start + 1]
+            s3_sync.metadata_migrator.run(**self.conf)
+            # with once = True we don't sleep
+            self.assertEqual(mocktime.sleep.call_args_list, [])
+            self.assertEqual('Finished cycle in 1.00s\n',
+                             self.pop_log_lines())
+
+    def test_run_forever(self):
+        start = time.time()
+        self.conf['once'] = False
+
+        class StopDeamon(Exception):
+            pass
+
+        with self.patch('process_migrations') as mock_process, \
+                self.patch('time') as mocktime:
+            mock_process.side_effect = [None, None, StopDeamon()]
+            mocktime.time.side_effect = [start + i for i in range(5)]
+            with self.assertRaises(StopDeamon):
+                s3_sync.metadata_migrator.run(**self.conf)
+            self.assertEqual(mocktime.sleep.call_args_list,
+                             [mock.call(29)] * 2)
+            self.assertEqual([
+                'Finished cycle in 1.00s, sleeping for 29.00s.',
+                'Finished cycle in 1.00s, sleeping for 29.00s.',
+            ], self.pop_log_lines().splitlines())
+
+    def test_conf_parsing(self):
+        config = {
+            'metadata_migrator_settings': {
+                'workers': 1337,
+                'items_chunk': 42,
+                'status_file': '/test/status',
+                'poll_interval': 60,
+                'process': 0,
+                'processes': 15,
+            },
+            'metadata_migrations': [
+                {'aws_bucket': 'test_bucket',
+                 'account': 'AUTH_test',
+                 'aws_identity': 'identity',
+                 'aws_secret': 'secret',
+                 'container': 'dst-container',
+                 'es_hosts': 'http://es.swift.lab:9200',
+                 'index_prefix': 'metadata_migrator_'}
+            ],
+            'swift_dir': '/foo/bar/swift',
+        }
+
+        old_run = s3_sync.metadata_migrator.run
+        with self.patch('setup_context') as mock_setup_context,\
+                self.patch('MetadataMigrator') as mock_migrator,\
+                self.patch('Status') as mock_status,\
+                self.patch(
+                    'run',
+                    new_callable=lambda: mock.Mock(side_effect=old_run))\
+                as mock_run:
+            mock_setup_context.return_value = (
+                mock.Mock(log_level='warn', console=True, once=True),
+                config)
+
+            s3_sync.metadata_migrator.main()
+            mock_status.assert_called_once_with('/test/status')
+            mock_migrator.assert_called_once_with(
+                config['metadata_migrations'][0],
+                mock_status.return_value, 42, 1337,
+                mock.ANY, mock.ANY, 0, 15)
+            mock_run.assert_called_once_with(
+                config['metadata_migrations'],
+                mock_status.return_value, mock.ANY,
+                mock.ANY, 42, 1337, 0, 15, 60, True)
+
+    @mock.patch('s3_sync.migrator.create_provider')
+    def test_migrate_all_containers_error(self, create_provider_mock):
+        provider_mock = mock.Mock()
+        provider_mock.list_buckets.side_effect = RuntimeError('Failed to list')
+        create_provider_mock.return_value = provider_mock
+        migrations = [
+            {'account': 'AUTH_dev',
+             'aws_bucket': '/*',
+             'aws_identity': 'identity',
+             'aws_secret': 'secret',
+             'es_hosts': 'http://null:9200',
+             'index_prefix': 'index_'}
+        ]
+
+        status = s3_sync.metadata_migrator.Status('status-path')
+        old_list = [
+            {'account': 'AUTH_dev',
+             'es_hosts': 'http://null:9200',
+             'index_prefix': 'index_',
+             'aws_bucket': 'bucket1',
+             'container': 'bucket1',
+             'aws_identity': 'identity'},
+            {'account': 'AUTH_dev',
+             'es_hosts': 'http://null:9200',
+             'index_prefix': 'index_',
+             'aws_bucket': 'bucket2',
+             'container': 'bucket2',
+             'aws_identity': 'identity'}]
+
+        def fake_load_list():
+            status.status_list = [dict(entry) for entry in old_list]
+
+        status.save_status_list = mock.Mock()
+        status.load_status_list = mock.Mock(side_effect=fake_load_list)
+
+        s3_sync.metadata_migrator.run(
+            migrations, status, mock.Mock(max_size=10), logging.getLogger(),
+            1000, 10, 0, 1, 10, True)
+        self.assertEqual(old_list, status.status_list)
+
+
+class TestESInternalClient(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'account': 'AUTH_swiftaccount',
+            'aws_bucket': 'bucket',
+            'aws_identity': 'identity',
+            'aws_secret': 'secret',
+            'container': 'swift-container',
+            'index_prefix': 'index_prefix_',
+            'es_hosts': 'http://elastic:9200',
+            'parse_json': True,
+            'older_than': 0,
+            'prefix': "",
+            'propagate_account_metadata': False,
+            'protocol': 's3',
+            'remote_account': ""}
+        self.elasticsearch = mock.Mock()
+        self.logger = logging.getLogger()
+        self.stream = StringIO()
+        self.logger.addHandler(logging.StreamHandler(self.stream))
+        self.swift_dir = '/etc/swift'
+        self.es_client =\
+            s3_sync.metadata_migrator.ESInternalClient(
+                self.config,
+                self.swift_dir, self.logger)
+        self.es_client._verified_indices = {}
+
+        self.elasticsearch = mock.Mock()
+        self.es_object = {'_source': {
+                          'x-swift-object': 'a-swift-object',
+                          'x-swift-container': 'a-swift-container',
+                          'x-swift-account': 'a-swift-account',
+                          'etag': 'etag',
+                          'content-type': 'application/foo',
+                          'foo': 'bar',
+                          'content-length': '100',
+                          'last-modified': '1534426198000',
+                          'content-location': 'Storage;bucket;prefix'}}
+        self.es_converted_object = {
+            'hash': 'etag',
+            'name': 'a-swift-object',
+            'bytes': '100',
+            'last_modified': '2018-08-16T13:29:58.000000',
+            'content_type': 'application/foo',
+            'content-location': 'Storage;bucket;prefix'}
+        self.es_remote_object = {
+            'hash': 'etag',
+            'name': 'a-remote-object',
+            'bytes': '100',
+            'last_modified': '2018-08-16T13:29:58.000000',
+            'content_type': 'application/foo',
+            'foo': 'bar',
+            'content-location': 'Storage;bucket;prefix'}
+        self.es_remote_headers = {
+            'etag': 'etag',
+            'Content-Length': '100',
+            'last-modified': 'Mon, 20 Nov 1995 19:12:08 -0500',
+            'x-timestamp': '1534426198',
+            'foo': 'bar'}
+
+        self.elasticsearch.get.return_value = self.es_object
+        self.elasticsearch.delete.return_value = self.es_object
+        self.elasticsearch.create.return_value = self.es_object
+        self.elasticsearch.index.return_value = self.es_object
+        self.elasticsearch.indices.exists.return_value = True
+        self.elasticsearch.indices.delete.return_value = 'dog'
+        self.elasticsearch.indices.put_mapping.return_value = 'dog'
+        self.elasticsearch.indices.get_mapping.return_value = {
+            'index_prefix_account_container': {
+                'mappings': {
+                    'object': {
+                        '_meta': {
+                            'foo': 'bar'
+                        },
+                        'properties': {
+                            'foo': 'text'
+                        }
+                    }
+                }
+            }
+        }
+
+        self.es_client.__get_es_conn = self.es_client._get_es_conn
+        self.es_client._get_es_conn =\
+            mock.Mock(return_value=self.elasticsearch)
+
+    def test_get_es_conn(self):
+        class mock_es:
+            def __init__(self):
+                pass
+
+            def info(self):
+                return {'version': {'number': '6.0.0'}}
+
+        with mock.patch('elasticsearch.Elasticsearch',
+                        return_value=mock_es()) as es_mock:
+                self.es_client.__get_es_conn(self.config)
+                es_mock.assert_called_once_with(
+                    'http://elastic:9200',
+                    ca_certs=None,
+                    verify_certs=True)
+                self.es_client.__get_es_conn(self.config)
+                es_mock.assert_called_once()
+
+    def test_get_object_metadata(self):
+        resp = self.es_client.get_object_metadata(
+            self.config, 'account', 'container', 'key')
+        self.elasticsearch.get.assert_called_once_with(
+            doc_type='object',
+            id=mock.ANY,
+            index="%saccount_container" % self.config['index_prefix']
+        )
+        self.assertEqual(resp, self.es_converted_object)
+
+    def test_get_object_metadata_error(self):
+        self.elasticsearch.get.side_effect = (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.get_object_metadata(self.config,
+                                               'account',
+                                               'container', 'key')
+            self.elasticsearch.get.assert_called_once_with(
+                doc_type='object',
+                id=mock.ANY,
+                index="%saccount_container" % self.config['index_prefix']
+            )
+
+    def test_delete_object(self):
+        self.es_client.delete_object(self.config, 'account', 'container',
+                                     'key', {})
+        self.elasticsearch.delete.assert_called_once_with(
+            doc_type='object',
+            id=mock.ANY,
+            index="%saccount_container" % self.config['index_prefix']
+        )
+
+    def test_delete_object_errors(self):
+        self.elasticsearch.delete.side_effect = (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.delete_object(self.config,
+                                         'account',
+                                         'container', 'key', {})
+
+    def test_upload_object(self):
+        self.es_client._verified_mappings = {self.config['es_hosts']: True}
+        self.es_client.upload_object(self.config,
+                                     'content',
+                                     'account',
+                                     'container', 'key',
+                                     self.es_remote_headers)
+        _id = '2eb2d1ac01fa01f8e2d5c36ea26e148a' +\
+              'fa8da234170c9c28bd8044beacd4ce67'
+        self.elasticsearch.index.assert_called_once_with(
+            body={'x-swift-container': 'container',
+                  'content-length': '100',
+                  'x-swift-account': 'account',
+                  'content-location': 'AWS S3;bucket;',
+                  'last-modified': 816912728000,
+                  'etag': 'etag',
+                  'x-timestamp': 1534426198000,
+                  'x-object-transient-sysmeta-multi-cloud-internal-migrator':
+                      1534426198000,
+                  'x-swift-object': u'key'},
+            doc_type='object',
+            id=_id,
+            index=u'index_prefix_account_container',
+            pipeline=None)
+
+    def test_upload_object_verifies_mapping(self):
+        with mock.patch.object(self.es_client,
+                               '_verify_mapping',
+                               return_value=True) as vm_mock:
+                self.es_client.upload_object(self.config,
+                                             'content',
+                                             'account',
+                                             'container', 'key',
+                                             self.es_remote_headers)
+                vm_mock.assert_called_once_with(
+                    self.config,
+                    'index_prefix_account_container')
+
+    def test_upload_object_error(self):
+        self.elasticsearch.create.side_effect = (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.upload_object(self.config,
+                                         'content',
+                                         'account',
+                                         'container', 'key', {})
+            self.elasticsearch.create.assert_called_once_with(
+                doc_type='object',
+                id=mock.ANY,
+                index="%saccount_container" % self.config['index_prefix']
+            )
+
+    def test_create_container(self):
+        self.es_client.create_container(self.config,
+                                        'account',
+                                        'container', {})
+        self.elasticsearch.indices.create.assert_called_once_with(
+            body={
+                'mappings': {
+                    'object': {
+                        'properties': {
+                            'x-swift-container': {'type': 'string'},
+                            'content-length': {'type': 'long'},
+                            'x-swift-account': {'type': 'string'},
+                            'last-modified': {'type': 'date'},
+                            'x-object-manifest': {'type': 'string'},
+                            'x-timestamp': {'type': 'date'},
+                            'etag': {'index':
+                                     'not_analyzed', 'type': 'string'},
+                            'x-trans-id': {'index': 'not_analyzed',
+                                           'type': 'string'},
+                            'x-swift-object': {'type': 'string'},
+                            'x-static-large-object': {'type': 'boolean'},
+                            'content-type': {'type': 'string'}},
+                        '_meta': {}}}},
+            index=u'index_prefix_account_container')
+
+    def test_create_container_error(self):
+        self.elasticsearch.indices.create.side_effect = (Exception('barfs'))
+        resp = self.es_client.create_container(self.config,
+                                               'account',
+                                               'container', {})
+        self.assertIsInstance(
+            resp,
+            s3_sync.metadata_migrator.ESInternalClientRequest)
+
+    def test_container_exists(self):
+        resp = self.es_client.container_exists(self.config,
+                                               'account',
+                                               'container')
+        self.elasticsearch.indices.exists.assert_called_once_with(
+            index=u'index_prefix_account_container')
+
+        self.assertEqual(resp, True)
+
+    def test_container_exists_generic_error(self):
+        self.elasticsearch.indices.exists.side_effect = (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.container_exists(self.config,
+                                            'account',
+                                            'container')
+
+    def test_container_exists_404(self):
+        self.elasticsearch.indices.exists.return_value = False
+        resp = self.es_client.container_exists(self.config,
+                                               'account',
+                                               'container')
+        self.assertEqual(resp, False)
+
+    def test_get_container_metadata(self):
+        resp = self.es_client.get_container_metadata(self.config,
+                                                     'account',
+                                                     'container')
+        self.elasticsearch.indices.get_mapping.assert_called_once_with(
+            index=u'index_prefix_account_container')
+        self.assertEqual(resp, {'foo': 'bar'})
+
+    def test_get_container_metadata_error(self):
+        self.elasticsearch.indices.get_mapping.side_effect =\
+            (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.get_container_metadata(self.config,
+                                                  'account',
+                                                  'container')
+
+    def test_delete_container(self):
+        req = self.es_client.delete_container(self.config,
+                                              'account',
+                                              'container')
+        self.elasticsearch.indices.delete.assert_called_once_with(
+            index=u'index_prefix_account_container')
+        self.assertIsInstance(
+            req,
+            s3_sync.metadata_migrator.ESInternalClientRequest)
+        self.assertEqual(req.response.status_int, 200)
+
+    def test_delete_container_error(self):
+        self.elasticsearch.indices.delete.side_effect = (Exception('barfs'))
+        with self.assertRaises(s3_sync.metadata_migrator.ESUnexpectedResponse):
+            self.es_client.delete_container(self.config,
+                                            'account',
+                                            'container')
+
+    def test_set_container_metadata(self):
+        req = self.es_client.set_container_metadata(self.config,
+                                                    'account',
+                                                    'container',
+                                                    {'foo': 'bar'})
+        self.elasticsearch.indices.get_mapping.assert_called_once_with(
+            doc_type='object', index='index_prefix_account_container')
+        self.elasticsearch.indices.put_mapping.assert_called_once_with(
+            body={'_meta': {'foo': 'bar'}, 'properties': {'foo': 'text'}},
+            doc_type='object',
+            index=u'index_prefix_account_container')
+        self.assertIsInstance(
+            req, s3_sync.metadata_migrator.ESInternalClientRequest)
+        self.assertEqual(req.response.status_int, 200)
+
+    def test_set_container_metadata_missing_mapping_meta(self):
+        with mock.patch.object(
+            self.elasticsearch.indices,
+            'get_mapping',
+            return_value={
+                'index_prefix_account_container': {
+                    'mappings': {
+                        'object': {
+                            'properties': {'foo': 'text'}}}}}):
+            self.es_client.set_container_metadata(self.config,
+                                                  'account',
+                                                  'container', {'foo': 'bar'})
+            self.elasticsearch.indices.put_mapping.assert_called_once_with(
+                body={'_meta': {'foo': 'bar'}, 'properties': {'foo': 'text'}},
+                doc_type='object',
+                index=u'index_prefix_account_container')
+
+    def test_set_container_metadata_get_mapping_error(self):
+        self.elasticsearch.indices.get_mapping.side_effect =\
+            (Exception('barfs'))
+        req = self.es_client.set_container_metadata(self.config,
+                                                    'account',
+                                                    'container',
+                                                    {'foo': 'bar'})
+        self.assertIsInstance(
+            req, s3_sync.metadata_migrator.ESInternalClientRequest)
+        self.assertEqual(req.response.status_int, 502)
+
+    def test_set_container_metadata_put_mapping_error(self):
+        self.elasticsearch.indices.put_mapping.side_effect =\
+            (Exception('barfs'))
+        req = self.es_client.set_container_metadata(self.config,
+                                                    'account',
+                                                    'container',
+                                                    {'foo': 'bar'})
+        self.assertIsInstance(
+            req, s3_sync.metadata_migrator.ESInternalClientRequest)
+        self.assertEqual(req.response.status_int, 502)
+
+    def test_set_account_meta(self):
+        req = self.es_client.set_account_metadata('account', {'foo': 'bar'})
+        self.assertIsInstance(
+            req, s3_sync.metadata_migrator.ESInternalClientRequest)
+        self.assertEqual(req.response.status_int, 200)
+
+    def test_str(self):
+        self.assertIsInstance(str(self.es_client), basestring)
+
+    def test_make_request(self):
+        with self.assertRaises(NotImplementedError):
+            self.es_client.make_request('GET', '/', {}, {}, None, None)
+
+    def test_es_exception_as_request(self):
+        expected_requests = {
+            elasticsearch.ImproperlyConfigured(): 400,
+            elasticsearch.SerializationError(): 422,
+            elasticsearch.TransportError('N/A', 'barfed'): None,
+            elasticsearch.TransportError(418, 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): None,
+            elasticsearch.ConnectionError('N/A', 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): 502,
+            elasticsearch.ConnectionTimeout('N/A', 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): 502,
+            elasticsearch.SSLError('N/A', 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): 502,
+            elasticsearch.NotFoundError('N/A', 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): 404,
+            elasticsearch.ConflictError('N/A', 'barfed', {
+                'error': {
+                    'root_cause': [
+                        {'reason': ''}
+                    ]
+                }
+            }): 409,
+            elasticsearch.RequestError(): 400,
+            TypeError(): 502}
+
+        for exception, status_int in expected_requests.items():
+            r = self.es_client._es_exception_as_request(exception)
+            self.assertIsInstance(
+                r, s3_sync.metadata_migrator.ESInternalClientRequest)
+            if status_int:
+                self.assertEqual(r.response.status_int, status_int)
+                self.assertEqual(r.get_response().status_int, status_int)
+            else:
+                self.assertEqual(r.response.status_int, exception.status_code)
+                self.assertEqual(r.get_response().status_int,
+                                 exception.status_code)
+
+    def test_es_iteration_selector(self):
+        self.es_client.set_account_metadata('account', {'foo': 'bar'})
+        with mock.patch.object(self.es_client,
+                               '_es_iter_containers', return_value=None) as c:
+            with mock.patch.object(self.es_client, '_es_iter_objects',
+                                   return_value=None) as o:
+                self.es_client.es_iter_items(
+                    self.es_client.config, 'AUTH_test', 'bucket', '', '')
+                self.es_client.es_iter_items(
+                    self.es_client.config, 'AUTH_test', '', '', '')
+                self.es_client.es_iter_items(
+                    self.es_client.config, 'AUTH_test', None, '', '')
+                o.assert_has_calls(
+                    [mock.call(self.es_client.config,
+                     'AUTH_test', 'bucket', '', '')],
+                    [mock.call(self.es_client.config,
+                     'AUTH_test', '', '', '')])
+                c.assert_has_calls([
+                    mock.call(self.es_client.config,
+                              'AUTH_test', '', '')])
+
+    def test_es_iter_objects(self):
+        self.es_client.SWIFT_PAGINATION_LIMIT = 10
+
+        def _set_es_iter_objects_response(count):
+            def _fake_search(index, doc_type, size, body):
+                try:
+                    start = int(body['search_after'][0])
+                except KeyError:
+                    start = 0
+
+                es_response = {'hits': {'hits': []}}
+                if (start >= count):
+                    return es_response
+                if (start + self.es_client.SWIFT_PAGINATION_LIMIT) >= count:
+                    end = count
+                else:
+                    end = start + self.es_client.SWIFT_PAGINATION_LIMIT
+
+                internal_header = s3_sync.utils.get_sys_migrator_header(
+                    'object')
+                for i in range(start + 1, end + 1):
+                    resp = {
+                        "_id": "id%s" % i,
+                        "_index": "index",
+                        "_score": 1.0,
+                        "_source": {
+                            "content-length": i,
+                            "content-location": "location%s" % i,
+                            "content-type": "content-type",
+                            "etag": "etag%s" % i,
+                            "last-modified": int(i * 100),
+                            internal_header: int(i * 2),
+                            "x-swift-account": "account",
+                            "x-swift-container": "container",
+                            "x-swift-object": "object%s" % i,
+                            "x-timestamp": 1533560136000
+                        },
+                        "_type": "object",
+                        "sort": ["%s" % i]
+                    }
+                    es_response['hits']['hits'].append(resp)
+
+                return es_response
+
+            self.elasticsearch.search.side_effect = _fake_search
+
+        def _get_iter_objects_expected_responses(count):
+
+            def _last_modified(ts):
+                return datetime.datetime.utcfromtimestamp(
+                    int(int(ts) / 1000)).strftime(SWIFT_TIME_FMT)
+
+            iter_response = []
+            for x in range(count + 1):
+                i = x + 1
+                internal_header = s3_sync.utils.get_sys_migrator_header(
+                    'object')
+                iter_response.append({
+                    "hash": "etag%s" % i,
+                    "name": "object%s" % i,
+                    "content_type": "content-type",
+                    "bytes": i,
+                    "last_modified": _last_modified(int(i * 100)),
+                    internal_header: int(i * 2),
+                    "content-location": "location%s" % i})
+
+            return iter(iter_response)
+
+        def _get_iter_objects_expected_calls(count, marker=None, prefix=None):
+            calls = []
+            _count = count / self.es_client.SWIFT_PAGINATION_LIMIT
+            if (count % self.es_client.SWIFT_PAGINATION_LIMIT):
+                _count += 1
+
+            callcount = 0
+            for x in range(_count):
+                i = x + 1
+                body = {
+                    "sort": [{"x-swift-object.keyword": {"order": "asc"}}],
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {"match": {"x-swift-account": u'account'}},
+                                {"match": {"x-swift-container": u'container'}},
+                                {"exists": {"field": "x-swift-object"}}
+                            ]
+                        }
+                    }
+                }
+
+                if i > 1:
+                    body['search_after'] =\
+                        ["%s" % int((i - 1) *
+                         self.es_client.SWIFT_PAGINATION_LIMIT)]
+
+                calls.append(
+                    mock.call(
+                        index=u'index_prefix_account_container',
+                        doc_type='object',
+                        size=self.es_client.SWIFT_PAGINATION_LIMIT,
+                        body=body))
+                callcount += 1
+
+            return calls
+
+        for count in [0, 1, 5, 9, 10, 11, 19, 20, 21, 100]:
+            _set_es_iter_objects_response(count)
+            exp_results = _get_iter_objects_expected_responses(count)
+
+            iterator = self.es_client._es_iter_objects(
+                self.es_client.config,
+                'account',
+                'container',
+                None,
+                None)
+
+            for i in range(1, count + 1):
+                real = iterator.next()
+                expected = exp_results.next()
+                self.assertEqual(real, expected)
+
+            self.elasticsearch.search.assert_has_calls(
+                _get_iter_objects_expected_calls(count))
+
+    def test_es_iter_containers(self):
+        self.es_client.SWIFT_PAGINATION_LIMIT = 10
+
+        def _set_es_iter_containers_response(count):
+
+            def _fake_get(index_prefix):
+                indices = {}
+                for i in range(count + 1):
+                    indices["%s%s_%s" % (self.config['index_prefix'],
+                            'account', i)] = True
+                return indices
+
+            self.elasticsearch.indices.get.side_effect = _fake_get
+
+        def _get_iter_containers_expected_responses(count):
+            iter_response = []
+            entries = []
+            for i in range(count + 1):
+                entries.append(str(i))
+            for i in sorted(entries):
+                iter_response.append({'name': str(i).encode('utf-8')})
+            return iter(iter_response)
+
+        def _get_iter_containers_expected_calls(count, marker=None,
+                                                prefix=None):
+            calls = []
+            arg = "%s%s_*" % (self.config['index_prefix'],
+                              'account')
+            calls.append(mock.call(arg.encode('utf-8')))
+            return calls
+
+        for count in [0, 1, 5, 9, 10, 11, 19, 20, 21, 100]:
+            _set_es_iter_containers_response(count)
+            exp_results = _get_iter_containers_expected_responses(count)
+
+            iterator = self.es_client._es_iter_containers(
+                self.es_client.config,
+                'account',
+                None,
+                None)
+
+            for i in range(0, count + 1):
+                real = iterator.next()
+                expected = exp_results.next()
+                self.assertEqual(real, expected)
+
+            self.elasticsearch.indices.get.assert_has_calls(
+                _get_iter_containers_expected_calls(count))


### PR DESCRIPTION
Adds a metadata migrator process, based heavily on the existing migrator, to index remote object store metadata into a local Elasticsearch cluster.

## Use
Configure additional `metadata_migrations` and `metadata_migrator_settings` sections in `sync.json` as per the example at `containers/swift-s3-sync/swift-s3-sync.conf`.

Then, start the metadata migrator in the same way as the migrator:

```
/opt/ss/bin/python /opt/ss/bin/swift-metadata-migrator --config /etc/swift-s3-sync/sync.json
```
## Behaviour
The daemon will create new Elasticsearch indices for each remote bucket / container it encounters (see the naming rules below). 

Metadata for each object in the remote bucket is indexed into this index in a similar way to [metadata sync](https://github.com/swiftstack/swift-metadata-sync).

Bucket / container metadata encountered on the remote is added to the [_meta field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html) of the corresponding Elasticsearch index; accounts have no corresponding structure in Elasticsearch, so their metadata is ignored.

Unlike the migrator, no special allowances are made for Swift large objects of objects with versioning enabled. In these cases, only metadata from the configured remote bucket will be indexed - in the case of a large object, for example, only the manifest is considered, not the segments.

## Configuration
Configuration is kept in the standard `sync.json` config file in two new sections:

### `metadata_migrator_settings`
Global config for the metadata migrator daemon - takes the same config settings as the existing `migrator_settings` config section.

### `metadata_migrations`
List of configured metadata migrations. This takes the same settings as the migrator, but also supports:

 - `es_hosts`:  (Required) The local Elasticsearch endpoint.
 - `index_prefix`: (Required) A global prefix prepended to all Elasticsearch indices created by the metadata migrator.
 - `parse_json`: (Optional, defaults to `false`) Optionally indexes metadata values as JSON into Elasticsearch, in the [same way as metadata sync](https://github.com/swiftstack/swift-metadata-sync/commit/77ca63013bd7192bad9b480a4ea8abcc2614d44a).
 - `verify_certs`: (Optional, defaults to `true`) If set `True` (the default), Elasticsearch connections will insist on TLS certificate verification when connecting to HTTP endpoints.
 - `ca_certs`: (Optional, no default) An optional path to a local PEM file containing the CA certificate for HTTP Elasticsearch connections.

Additionally, the behavior of the migrator settings below is somewhat different:

 - `account`: Sets the `x-swift-account` field property for documents being indexed into Elasticsearch. This also affects the auto-created index names when the metadata migrator creates a new index.
 - `container`:  Sets the `x-swift-container` field property for documents being indexed into Elasticsearch. Does not affect the name of auto-created Elasticsearch indices.
 - `aws_bucket`: As with the migrator, this can be set to a single bucket name, or '/*'. When '/*', a new Elasticsearch index per bucket will be created; each index created this way is named as 

```
    <INDEX_PREFIX>_<ACCOUNT>_<BUCKET>
```

...where INDEX_PREFIX is the `index_prefix` setting above, ACCOUNT is the `account` settings above, and BUCKET is the name of the remote bucket or container.

 

