### PR TITLE
Safer Remote Delete After for SLOs

### DIFF
--- a/containers/swift-s3-sync/swift-s3-sync.conf
+++ b/containers/swift-s3-sync/swift-s3-sync.conf
@@ -130,7 +130,8 @@
             "merge_namespaces": true,
             "protocol": "swift",
             "retain_local": false,
-            "remote_delete_after": 100
+            "remote_delete_after": 100,
+            "remote_delete_after_addition": 172800
         },
         {
             "account": "AUTH_test",


### PR DESCRIPTION
This sets the delete after for SLO segments to be 24 hours later than
configured for objects. Since the segments are uploaded just before the
manifest, this ensures that the manifest expires before the objects.